### PR TITLE
ocw-www config updates and missing fields

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -36,9 +36,18 @@ collections:
         name: link_url
         widget: string
 
-      - label: Image File
+      - label: Image
         name: image
-        widget: file
+        widget: relation
+        collection: resource
+        display_field: title
+        multiple: false
+        min: 1
+        max: 1
+        filter:
+          field: "filetype"
+          filter_type: "equals"
+          value: "Image"
 
       - label: Image Alt
         name: image_alt
@@ -88,7 +97,16 @@ collections:
 
       - label: Image
         name: image
-        widget: file
+        widget: relation
+        collection: resource
+        display_field: title
+        multiple: false
+        min: 1
+        max: 1
+        filter:
+          field: "filetype"
+          filter_type: "equals"
+          value: "Image"
 
       - label: Lead Quote
         name: leadquote
@@ -97,3 +115,25 @@ collections:
       - label: Body
         name: body
         widget: markdown
+
+  - name: resource
+    label: Resource
+    category: Content
+    folder: content
+    fields:
+      - label: "Title"
+        name: "title"
+        widget: "string"
+        required: true
+      - label: "Description"
+        name: "description"
+        widget: "text"
+      - label: "File"
+        name: "file"
+        widget: "file"
+      - label: "File Type"
+        required: true
+        name: "filetype"
+        options:
+          - "Image"
+        widget: "select"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -22,25 +22,25 @@ collections:
         name: title
         widget: string
 
-      - label: Link
-        name: link
-        widget: object
-        fields:
-          - label: Link Title
-            name: link_title
-            widget: string
+      - label: Subtitle
+        name: subtitle
+        widget: string
 
-          - label: Url
-            name: link_url
-            widget: string
+      - label: Link Title
+        name: link_title
+        widget: string
 
-          - label: Image File
-            name: image
-            widget: file
+      - label: Url
+        name: link_url
+        widget: string
 
-          - label: Image Alt
-            name: image_alt
-            widget: string
+      - label: Image File
+        name: image
+        widget: file
+
+      - label: Image Alt
+        name: image_alt
+        widget: string
 
   - category: Content
     folder: content/notifications
@@ -67,10 +67,6 @@ collections:
     fields:
       - label: Title
         name: title
-        widget: string
-
-      - label: Subtitle
-        name: subtitle
         widget: string
 
       - label: Name

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -38,16 +38,7 @@ collections:
 
       - label: Image
         name: image
-        widget: relation
-        collection: resource
-        display_field: title
-        multiple: false
-        min: 1
-        max: 1
-        filter:
-          field: "filetype"
-          filter_type: "equals"
-          value: "Image"
+        widget: file
 
       - label: Image Alt
         name: image_alt
@@ -97,16 +88,7 @@ collections:
 
       - label: Image
         name: image
-        widget: relation
-        collection: resource
-        display_field: title
-        multiple: false
-        min: 1
-        max: 1
-        filter:
-          field: "filetype"
-          filter_type: "equals"
-          value: "Image"
+        widget: file
 
       - label: Lead Quote
         name: leadquote
@@ -115,25 +97,3 @@ collections:
       - label: Body
         name: body
         widget: markdown
-
-  - name: resource
-    label: Resource
-    category: Content
-    folder: content
-    fields:
-      - label: "Title"
-        name: "title"
-        widget: "string"
-        required: true
-      - label: "Description"
-        name: "description"
-        widget: "text"
-      - label: "File"
-        name: "file"
-        widget: "file"
-      - label: "File Type"
-        required: true
-        name: "filetype"
-        options:
-          - "Image"
-        widget: "select"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -54,6 +54,7 @@ collections:
       - label: Body
         name: body
         widget: markdown
+        minimal: true
 
       - label: Headless
         name: headless

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -8,6 +8,7 @@ collections:
       - label: Title
         name: title
         widget: string
+        required: true
 
       - label: Body
         name: body
@@ -21,6 +22,7 @@ collections:
       - label: Title
         name: title
         widget: string
+        required: true
 
       - label: Subtitle
         name: subtitle
@@ -50,6 +52,7 @@ collections:
       - label: Title
         name: title
         widget: string
+        required: true
 
       - label: Body
         name: body
@@ -69,6 +72,7 @@ collections:
       - label: Title
         name: title
         widget: string
+        required: true
 
       - label: Name
         name: name

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -1,13 +1,14 @@
 ---
 collections:
-  - category:  Content
+  - category: Content
     folder: content/pages
     label: Page
-    name: page
+    name: pages
     fields:
       - label: Title
         name: title
         widget: string
+
       - label: Body
         name: body
         widget: markdown
@@ -15,7 +16,7 @@ collections:
   - category: Content
     folder: content/promos
     label: Promo
-    name: promo
+    name: promos
     fields:
       - label: Title
         name: title
@@ -33,10 +34,6 @@ collections:
             name: link_url
             widget: string
 
-      - label: Image
-        name: image_object
-        widget: object
-        fields:
           - label: Image File
             name: image
             widget: file
@@ -48,11 +45,15 @@ collections:
   - category: Content
     folder: content/notifications
     label: Notification
-    name: notification
+    name: notifications
     fields:
       - label: Title
         name: title
         widget: string
+
+      - label: Body
+        name: body
+        widget: markdown
 
       - label: Headless
         name: headless
@@ -62,10 +63,14 @@ collections:
   - category: Content
     folder: content/testimonials
     label: Testimonial
-    name: testimonial
+    name: testimonials
     fields:
       - label: Title
         name: title
+        widget: string
+
+      - label: Subtitle
+        name: subtitle
         widget: string
 
       - label: Name
@@ -81,19 +86,11 @@ collections:
         widget: string
 
       - label: Image
-        name: image_object
-        widget: object
-        fields:
-          - label: Image File
-            name: image
-            widget: file
-
-          - label: Image Alt
-            name: image_alt
-            widget: string
+        name: image
+        widget: file
 
       - label: Lead Quote
-        name: lead_quote
+        name: leadquote
         widget: string
 
       - label: Body


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-hugo-projects/issues/5

#### What's this PR do?
This PR fixes a number of issues:
 - `name` property on collection items set to plurals to match `ocw-hugo-themes` so the `type` key is written out properly
 - `lead_quote` corrected to `leadquote`
 - `image_object` wrappers removed, as they create the object structure in the resulting front matter
 - `body` added to notifications
 - `subtitle` added to promos

#### How should this be manually tested?
- Create a new `WebsiteStarter` in `ocw-studio` RC Django admin
- Convert `ocw-www/ocw-studio.yaml` to JSON and paste it in the Config field for the starter
- Create a new `Website` using this starter
- Create one of each type of content, then hit the preview button
- Find the site's repo on https://github.mit.edu and look through the markdown
- Verify:
  - The `type` properties in the front matter of the various pieces of content are plural and match it's designated type in `ocw-hugo-themes/www/layouts/`
  - There are no `image_object` wrappers written into the front matter of any content
  - The newly added fields appear where they should
  - `lead_quote` in testimonials is now `leadquote`