### PR TITLE
resource definition and image relation widgets

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -39,7 +39,7 @@ collections:
       - label: Image
         name: image
         widget: relation
-        collection: image
+        collection: resource
         display_field: title
         multiple: false
         min: 1
@@ -94,7 +94,7 @@ collections:
       - label: Image
         name: image
         widget: relation
-        collection: image
+        collection: resource
         display_field: title
         multiple: false
         min: 1

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -38,11 +38,16 @@ collections:
 
       - label: Image
         name: image
-        widget: file
-
-      - label: Image Alt
-        name: image_alt
-        widget: string
+        widget: relation
+        collection: image
+        display_field: title
+        multiple: false
+        min: 1
+        max: 1
+        filter:
+          field: "filetype"
+          filter_type: "equals"
+          value: "Image"
 
   - category: Content
     folder: content/notifications
@@ -88,7 +93,16 @@ collections:
 
       - label: Image
         name: image
-        widget: file
+        widget: relation
+        collection: image
+        display_field: title
+        multiple: false
+        min: 1
+        max: 1
+        filter:
+          field: "filetype"
+          filter_type: "equals"
+          value: "Image"
 
       - label: Lead Quote
         name: leadquote
@@ -97,3 +111,45 @@ collections:
       - label: Body
         name: body
         widget: markdown
+
+  - category: Content
+    folder: content/resources
+    label: Resources
+    name: resource
+    fields:
+      - label: Title
+        name: title
+        required: true
+        widget: string
+      - label: Description
+        name: description
+        widget: markdown
+        minimal: true
+      - label: File Type
+        name: filetype
+        required: true
+        widget: select
+        options:
+          - Image
+          - Video
+          - Document
+          - Other
+      - label: File
+        name: file
+        widget: file
+
+      # show the field below only if the type of resource is "image"
+      - label: Image Metadata
+        name: metadata
+        widget: object
+        condition: { field: filetype, equals: Image }
+        fields:
+          - label: Text alternative
+            name: image-alt
+            widget: string
+          - label: Caption
+            name: caption
+            widget: string
+          - label: Credit
+            name: credit
+            widget: text


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/7

#### What's this PR do?
In an effort to build `ocw-www` content generated by `ocw-studio`, images will no longer be uploaded directly into the `static` folder of the `ocw-www` github repo and instead will be uploaded to `ocw-studio`.  This PR adds a definition for a resource collection with support for extra metadata for images.  Relation widgets were also set on promos and testimonials filtering on the Image type resources.

#### How should this be manually tested?
 - Convert the `ocw-www/ocw-studio.yaml` file to JSON, create a test `WebsiteStarter` in `ocw-studio` and paste our JSON in as the configuration
 - Create a test `Website` using the `WebsiteStarter` we created
 - Go to the "Resource" section and test uploading each type of resource
 - Go to the "Promo" section and create a test promo, linking it to the image resource you uploaded
 - Repeat the previous step for the "Testimonial" section
 - Click the "preview" button and confirm that markdown is generated at https://github.mit.edu
 - Ensure that the proper images were linked to the test Promo and Testimonial you created, linking them by uid