### PR TITLE
Add root-url-path to ocw-studio.yaml files

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -1,3 +1,3 @@
 ---
-base-url: courses
+root-url-path: courses
 collections:  []

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -1,2 +1,3 @@
 ---
+base-url: courses
 collections:  []

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -1,4 +1,5 @@
 ---
+base-url: ""
 collections:
   - category: Content
     folder: content/pages

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -1,5 +1,5 @@
 ---
-base-url: ""
+root-url-path: ""
 collections:
   - category: Content
     folder: content/pages


### PR DESCRIPTION
This depends on https://github.com/mitodl/ocw-studio/pull/338

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
- Partially addresses #336 

#### What's this PR do?
- Adds `root-url-path` to `ocw-studio.yml` files

#### How should this be manually tested?
- Start up ocw-studio on the `mb/siteconfigpath` branch
- Convert each of the modified yaml files to JSON and create new `WebsiteStarter`s with the JSON as the site config.  The configs should validate.
- Create a new site with each starter and add a resource, uploading a file.  Check the filepath of the uploaded file, it should start with the `base-url` value specified in the site config if any, then the `Website.name` value: `<root-url-path>/<site_name>`
