### PR TITLE
add basic pages and resources to courses

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -1,3 +1,58 @@
 ---
 root-url-path: courses
-collections:  []
+collections:
+  - category: Content
+    folder: content/pages
+    label: Page
+    name: pages
+    fields:
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Body
+        name: body
+        widget: markdown
+
+  - category: Content
+    folder: content/resources
+    label: Resources
+    name: resource
+    fields:
+      - label: Title
+        name: title
+        required: true
+        widget: string
+      - label: Description
+        name: description
+        widget: markdown
+        minimal: true
+      - label: File Type
+        name: filetype
+        required: true
+        widget: select
+        options:
+          - Image
+          - Video
+          - Document
+          - Other
+      - label: File
+        name: file
+        widget: file
+
+      # show the field below only if the type of resource is "image"
+      - label: Image Metadata
+        name: metadata
+        widget: object
+        condition: { field: filetype, equals: Image }
+        fields:
+          - label: Text alternative
+            name: image-alt
+            widget: string
+          - label: Caption
+            name: caption
+            widget: string
+          - label: Credit
+            name: credit
+            widget: text


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/12

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/4, we added an `ocw-studio` configuration for the `ocw-www` website.  This PR adds the `page` and `resource` collections to the `ocw-course` studio config as they exist in the `ocw-www` starter to the `ocw-course` starter to allow the uploading of resources and the creation of generic pages.

#### How should this be manually tested?
 - Set up `ocw-studio` locally or use the RC instance for testing and log in with an admin user
 - Add a `WebsiteStarter` in Django admin
 - Convert `ocw-course/ocw-studio.yaml` to JSON and paste it into the configuration field for your new `WebsiteStarter` and then save it
 - Verify that the config validates and the `WebsiteStarter` object is saved