### PR TITLE
add department numbers as a multiple choice select to the course starter

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -65,6 +65,50 @@ collections:
         name: sitemetadata
         label: Course Metadata
         fields:
+          - label: "Department Numbers"
+            max: 2
+            min: 1
+            multiple: true
+            name: "department_numbers"
+            options:
+              - '1'
+              - '2'
+              - '3'
+              - '4'
+              - '5'
+              - '6'
+              - '7'
+              - '8'
+              - '9'
+              - '10'
+              - '11'
+              - '12'
+              - '14'
+              - '15'
+              - '16'
+              - '17'
+              - '18'
+              - '20'
+              - 21A
+              - 21G
+              - 21H
+              - 21L
+              - 21M
+              - '22'
+              - '24'
+              - CC
+              - CMS-W
+              - EC
+              - ES
+              - ESD
+              - HST
+              - IDS
+              - MAS
+              - PE
+              - RES
+              - STS
+              - WGS
+            widget: "select"
           - label: Instructors
             name: instructors
             widget: relation


### PR DESCRIPTION
#### What are the relevant tickets?

Closes https://github.com/mitodl/ocw-hugo-projects/issues/19

#### What's this PR do?

This PR adds a multiple select of MIT department numbers to the Course Metadata collection.

#### How should this be manually tested?

 - Convert `ocw-course/ocw-studio.yaml` to JSON and paste it into a new Website Starter in your local instance of `ocw-studio` (or on RC).
 - Create a Website using this new Website Starter and go to the Course Metadata section.  Select some department numbers and make sure you can save.


