### PR TITLE
add course title

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -65,6 +65,10 @@ collections:
         name: sitemetadata
         label: Course Metadata
         fields:
+          - label: "Course Title"
+            name: "course_title"
+            widget: "string"
+            required: true
           - label: "Department Numbers"
             max: 2
             min: 1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/22

#### What's this PR do?
This PR adds the course title as a required field to the course metadata in the course starter.

#### How should this be manually tested?
 - Convert `ocw-course/ocw-studio.yaml` to JSON and paste it into a starter in either a locally running instance of `ocw-studio` or on RC
 - Create a Website using the new Website Starter you made and click on Metadata under settings
 - Ensure that Course Title is displayed as a string field

