### PR TITLE
add standard github issue / PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,28 @@
+---
+labels: Bug
+name: "Bug Report"
+about: "Something isn't quite right"
+---
+### Steps to Reproduce
+
+(List or Description)
+
+### Expected Behavior
+
+(Optional)
+
+### Actual Behavior
+
+(Optional)
+
+### Stacktrace
+
+(Optional)
+
+### Related Issues
+
+(Optional)
+
+### Screenshot or Screencast
+
+(Optional)

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,17 @@
+---
+name: New Feature
+about: "New feature to implement"
+---
+As a X, I'd like to Y
+
+#### Designs and Mockups
+
+
+
+#### Acceptance Criteria:
+
+- [ ] Requirement
+
+#### Out of Scope
+
+- Not going to do

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+#### Pre-Flight checklist
+
+- [ ] Testing
+  - [ ] Code is tested
+  - [ ] Changes have been manually tested
+
+#### What are the relevant tickets?
+(Required)
+
+#### What's this PR do?
+(Required)
+
+#### How should this be manually tested?
+(Required)
+
+#### Where should the reviewer start?
+(Optional)
+
+#### Any background context you want to provide?
+(Optional)
+
+#### Screenshots (if appropriate)
+(Optional)


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR adds basic Github Issue / PR templates to this repo

#### How should this be manually tested?
No testing required, this just copies in Github templates used in other projects
