### PR TITLE
remove max selection limit on department numbers

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -66,7 +66,6 @@ collections:
         label: Course Metadata
         fields:
           - label: "Department Numbers"
-            max: 2
             min: 1
             multiple: true
             name: "department_numbers"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-hugo-projects/issues/30

#### What's this PR do?
This PR removes the max selection limitation on departments that was accidentally added in the initial PR.

#### How should this be manually tested?
 - Convert `ocw-course/ocw-studio.yaml` to JSON
 - In `ocw-studio`, create a `WebsiteStarter` using this JSON
 - Create a `Website` using this starter
 - Go to the Course Metadata section and add more than 2 department numbers and click save
 - Verify that the metadata saved and there were no errors
