### PR TITLE
Added nav menu to site config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ $RECYCLE.BIN/
 
 # OSX
 .DS_Store
+
+.idea/

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -184,3 +184,17 @@ collections:
         name: headless
         widget: hidden
         default: true
+
+  - category: Settings
+    label: Menu
+    name: menu
+    files:
+      - file: config/_default/menus.yaml
+        name: navmenu
+        label: Navigation Menu
+        fields:
+          - {
+            "label": "Menu",
+            "name": "mainmenu",
+            "widget": "menu",
+          }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds a nav menu to the site config so that published course sites can have a Hugo menu configured

#### How should this be manually tested?
- Paste the site config into a new Website Starter in your local instance of `ocw-studio` (or on RC). The Django admin field is equipped to handle yaml or json, and will be automatically converted to json if yaml is pasted in.
- Create a Website using this new Website Starter, and create a few pages. 
- Go to settings > menu, add those pages and some external links to the menu, and save
- Check your exported site in Github and navigate to `/config/menu-sidenav.yml`. The content of that file should be a valid Hugo menu format, and should match the menu you arranged in OCWS