### PR TITLE
add course numbers

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -69,6 +69,14 @@ collections:
             name: "course_title"
             widget: "string"
             required: true
+          - label: "Primary Course Number"
+            name: "primary_course_number"
+            widget: "string"
+            required: true
+          - label: "Extra Course Numbers (comma separated list)"
+            name: "extra_course_numbers"
+            widget: "string"
+            required: true
           - label: "Department Numbers"
             max: 2
             min: 1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/25

#### What's this PR do?
This PR adds `primary_course_number` and `extra_course_numbers` as required string fields to the course site starter.  The `extra_course_numbers` field has traditionally been a list of strings in OCW, and for now we will simply be representing this with a comma separated string.  This has been noted in the label for the extra course numbers field, but in the future we should add validation or a `multiple: true` parameter to the string widget, or both.

#### How should this be manually tested?
- Paste the site config into a new Website Starter in your local instance of `ocw-studio` (or on RC). The Django admin field is equipped to handle yaml or json, and will be automatically converted to json if yaml is pasted in.
- Create a Website using this new Website Starter
- Go to Settings -> Metadata, add set both `primary_course_number` and `extra_course_numbers` and click Save
- Check your exported site in Github and navigate to `/data/course.json`.  You should see your course numbers in the file.
