### PR TITLE
add course feature tags to resources and course metadata

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -45,46 +45,46 @@ collections:
         widget: select
         multiple: true
         options:
-        - 'Course Introduction'
-        - 'Lecture Videos'
-        - 'Lecture Audio'
-        - 'Recitation Videos'
-        - 'Other Audio'
-        - 'Demonstration Audio'
-        - Music
-        - 'Other Video'
-        - 'Demonstration Videos'
-        - 'Video Materials'
-        - 'Competition Videos'
-        - 'Workshop Videos'
-        - Videos
-        - 'Tutorial Videos'
-        - 'Multiple Assignment Types'
-        - 'Multiple Assignment Types with Solutions'
-        - 'Activity Assignments'
-        - 'Activity Assignments with Examples'
-        - 'Design Assignments'
-        - 'Design Assignments with Examples'
-        - 'Media Assignments'
-        - 'Media Assignments with Examples'
-        - 'Presentation Assignments'
-        - 'Presentation Assignments with Examples'
-        - 'Problem Sets'
-        - 'Problem Sets with Solutions'
-        - 'Programming Assignments'
-        - 'Programming Assignments with Examples'
-        - 'Written Assignments'
-        - 'Written Assignments with Examples'
-        - 'Exam Materials'
-        - Exams
-        - 'Exams with Solutions'
-        - 'Image Gallery'
-        - Simulations
-        - 'Simulation Videos'
-        - 'Lecture Notes'
-        - 'Online Textbook'
-        - Projects
-        - 'Projects with Examples'
+          - 'Activity Assignment'
+          - 'Activity Assignment with Examples'
+          - 'Competition Video'
+          - 'Course Introduction'
+          - 'Demonstration Audio'
+          - 'Demonstration Video'
+          - 'Design Assignment'
+          - 'Design Assignment with Examples'
+          - 'Exam Material'
+          - Exam
+          - 'Exam with Solutions'
+          - 'Image Gallery'
+          - 'Lecture Audio'
+          - 'Lecture Note'
+          - 'Lecture Video'
+          - 'Media Assignment'
+          - 'Media Assignment with Examples'
+          - 'Multiple Assignment Types'
+          - 'Multiple Assignment Types with Solutions'
+          - Music
+          - 'Online Textbook'
+          - 'Other Audio'
+          - 'Other Video'
+          - 'Presentation Assignment'
+          - 'Presentation Assignment with Examples'
+          - 'Problem Set'
+          - 'Problem Set with Solutions'
+          - 'Programming Assignment'
+          - 'Programming Assignment with Examples'
+          - Project
+          - 'Project with Examples'
+          - 'Recitation Video'
+          - 'Simulation Video'
+          - Simulation
+          - 'Tutorial Video'
+          - 'Video Material'
+          - Video
+          - 'Workshop Video'
+          - 'Written Assignment'
+          - 'Written Assignment with Examples'
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
         name: metadata
@@ -169,46 +169,46 @@ collections:
             widget: select
             multiple: true
             options:
-            - 'Course Introduction'
-            - 'Lecture Videos'
-            - 'Lecture Audio'
-            - 'Recitation Videos'
-            - 'Other Audio'
-            - 'Demonstration Audio'
-            - Music
-            - 'Other Video'
-            - 'Demonstration Videos'
-            - 'Video Materials'
-            - 'Competition Videos'
-            - 'Workshop Videos'
-            - Videos
-            - 'Tutorial Videos'
-            - 'Multiple Assignment Types'
-            - 'Multiple Assignment Types with Solutions'
-            - 'Activity Assignments'
-            - 'Activity Assignments with Examples'
-            - 'Design Assignments'
-            - 'Design Assignments with Examples'
-            - 'Media Assignments'
-            - 'Media Assignments with Examples'
-            - 'Presentation Assignments'
-            - 'Presentation Assignments with Examples'
-            - 'Problem Sets'
-            - 'Problem Sets with Solutions'
-            - 'Programming Assignments'
-            - 'Programming Assignments with Examples'
-            - 'Written Assignments'
-            - 'Written Assignments with Examples'
-            - 'Exam Materials'
-            - Exams
-            - 'Exams with Solutions'
-            - 'Image Gallery'
-            - Simulations
-            - 'Simulation Videos'
-            - 'Lecture Notes'
-            - 'Online Textbook'
-            - Projects
-            - 'Projects with Examples'
+              - 'Activity Assignments'
+              - 'Activity Assignments with Examples'
+              - 'Competition Videos'
+              - 'Course Introduction'
+              - 'Demonstration Audio'
+              - 'Demonstration Videos'
+              - 'Design Assignments'
+              - 'Design Assignments with Examples'
+              - 'Exam Materials'
+              - Exams
+              - 'Exams with Solutions'
+              - 'Image Gallery'
+              - 'Lecture Audio'
+              - 'Lecture Notes'
+              - 'Lecture Videos'
+              - 'Media Assignments'
+              - 'Media Assignments with Examples'
+              - 'Multiple Assignment Types'
+              - 'Multiple Assignment Types with Solutions'
+              - Music
+              - 'Online Textbook'
+              - 'Other Audio'
+              - 'Other Video'
+              - 'Presentation Assignments'
+              - 'Presentation Assignments with Examples'
+              - 'Problem Sets'
+              - 'Problem Sets with Solutions'
+              - 'Programming Assignments'
+              - 'Programming Assignments with Examples'
+              - Projects
+              - 'Projects with Examples'
+              - 'Recitation Videos'
+              - 'Simulation Videos'
+              - Simulations
+              - 'Tutorial Videos'
+              - 'Video Materials'
+              - Videos
+              - 'Workshop Videos'
+              - 'Written Assignments'
+              - 'Written Assignments with Examples'
           - label: Instructors
             name: instructors
             widget: relation

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -40,7 +40,51 @@ collections:
       - label: File
         name: file
         widget: file
-
+      - label: "Course Feature Tags"
+        name: "course_feature_tags"
+        widget: select
+        multiple: true
+        options:
+        - 'Course Introduction'
+        - 'Lecture Videos'
+        - 'Lecture Audio'
+        - 'Recitation Videos'
+        - 'Other Audio'
+        - 'Demonstration Audio'
+        - Music
+        - 'Other Video'
+        - 'Demonstration Videos'
+        - 'Video Materials'
+        - 'Competition Videos'
+        - 'Workshop Videos'
+        - Videos
+        - 'Tutorial Videos'
+        - 'Multiple Assignment Types'
+        - 'Multiple Assignment Types with Solutions'
+        - 'Activity Assignments'
+        - 'Activity Assignments with Examples'
+        - 'Design Assignments'
+        - 'Design Assignments with Examples'
+        - 'Media Assignments'
+        - 'Media Assignments with Examples'
+        - 'Presentation Assignments'
+        - 'Presentation Assignments with Examples'
+        - 'Problem Sets'
+        - 'Problem Sets with Solutions'
+        - 'Programming Assignments'
+        - 'Programming Assignments with Examples'
+        - 'Written Assignments'
+        - 'Written Assignments with Examples'
+        - 'Exam Materials'
+        - Exams
+        - 'Exams with Solutions'
+        - 'Image Gallery'
+        - Simulations
+        - 'Simulation Videos'
+        - 'Lecture Notes'
+        - 'Online Textbook'
+        - Projects
+        - 'Projects with Examples'
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
         name: metadata
@@ -120,6 +164,51 @@ collections:
               - 'Both'
               - 'Non Credit'
             widget: "select"
+          - label: "Course Feature Tags"
+            name: "course_feature_tags"
+            widget: select
+            multiple: true
+            options:
+            - 'Course Introduction'
+            - 'Lecture Videos'
+            - 'Lecture Audio'
+            - 'Recitation Videos'
+            - 'Other Audio'
+            - 'Demonstration Audio'
+            - Music
+            - 'Other Video'
+            - 'Demonstration Videos'
+            - 'Video Materials'
+            - 'Competition Videos'
+            - 'Workshop Videos'
+            - Videos
+            - 'Tutorial Videos'
+            - 'Multiple Assignment Types'
+            - 'Multiple Assignment Types with Solutions'
+            - 'Activity Assignments'
+            - 'Activity Assignments with Examples'
+            - 'Design Assignments'
+            - 'Design Assignments with Examples'
+            - 'Media Assignments'
+            - 'Media Assignments with Examples'
+            - 'Presentation Assignments'
+            - 'Presentation Assignments with Examples'
+            - 'Problem Sets'
+            - 'Problem Sets with Solutions'
+            - 'Programming Assignments'
+            - 'Programming Assignments with Examples'
+            - 'Written Assignments'
+            - 'Written Assignments with Examples'
+            - 'Exam Materials'
+            - Exams
+            - 'Exams with Solutions'
+            - 'Image Gallery'
+            - Simulations
+            - 'Simulation Videos'
+            - 'Lecture Notes'
+            - 'Online Textbook'
+            - Projects
+            - 'Projects with Examples'
           - label: Instructors
             name: instructors
             widget: relation

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -45,46 +45,49 @@ collections:
         widget: select
         multiple: true
         options:
-          - 'Activity Assignment'
-          - 'Activity Assignment with Examples'
-          - 'Competition Video'
+          - 'Activity Assignments'
+          - 'Activity Assignments with Examples'
+          - 'Competition Videos'
           - 'Course Introduction'
           - 'Demonstration Audio'
-          - 'Demonstration Video'
-          - 'Design Assignment'
-          - 'Design Assignment with Examples'
-          - 'Exam Material'
-          - Exam
-          - 'Exam with Solutions'
+          - 'Demonstration Videos'
+          - 'Design Assignments'
+          - 'Design Assignments with Examples'
+          - 'Exam Materials'
+          - Exams
+          - 'Exams with Solutions'
           - 'Image Gallery'
+          - Labs
           - 'Lecture Audio'
-          - 'Lecture Note'
-          - 'Lecture Video'
-          - 'Media Assignment'
-          - 'Media Assignment with Examples'
+          - 'Lecture Notes'
+          - 'Lecture Videos'
+          - 'Media Assignments'
+          - 'Media Assignments with Examples'
           - 'Multiple Assignment Types'
           - 'Multiple Assignment Types with Solutions'
           - Music
           - 'Online Textbook'
           - 'Other Audio'
           - 'Other Video'
-          - 'Presentation Assignment'
-          - 'Presentation Assignment with Examples'
-          - 'Problem Set'
-          - 'Problem Set with Solutions'
-          - 'Programming Assignment'
-          - 'Programming Assignment with Examples'
-          - Project
-          - 'Project with Examples'
-          - 'Recitation Video'
-          - 'Simulation Video'
-          - Simulation
-          - 'Tutorial Video'
-          - 'Video Material'
-          - Video
-          - 'Workshop Video'
-          - 'Written Assignment'
-          - 'Written Assignment with Examples'
+          - 'Presentation Assignments'
+          - 'Presentation Assignments with Examples'
+          - 'Problem Sets'
+          - 'Problem Sets with Solutions'
+          - 'Programming Assignments'
+          - 'Programming Assignments with Examples'
+          - Projects
+          - 'Projects with Examples'
+          - Readings
+          - 'Recitation Videos'
+          - 'Simulation Videos'
+          - Simulations
+          - Tools
+          - 'Tutorial Videos'
+          - 'Video Materials'
+          - Videos
+          - 'Workshop Videos'
+          - 'Written Assignments'
+          - 'Written Assignments with Examples'
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
         name: metadata
@@ -181,6 +184,7 @@ collections:
               - Exams
               - 'Exams with Solutions'
               - 'Image Gallery'
+              - Labs
               - 'Lecture Audio'
               - 'Lecture Notes'
               - 'Lecture Videos'
@@ -200,9 +204,11 @@ collections:
               - 'Programming Assignments with Examples'
               - Projects
               - 'Projects with Examples'
+              - Readings
               - 'Recitation Videos'
               - 'Simulation Videos'
               - Simulations
+              - Tools
               - 'Tutorial Videos'
               - 'Video Materials'
               - Videos


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/24

#### What's this PR do?
This PR adds the course feature tags from `ocw-data-parser` (https://github.com/mitodl/ocw-data-parser/blob/2580dcaf52be4e2e0c1098be527bd19cfc8e7288/ocw_data_parser/course_feature_tags.py#L59-L101) as a multiple choice list to both the course metadata and course resources.  The tags you can set on a Resource have been edited to be singular rather than plural.  The tags are a simple list of strings and multiple can be associated with both resources and the course metadata.

#### How should this be manually tested?
- Paste the site config into a new Website Starter in your local instance of `ocw-studio` (or on RC). The Django admin field is equipped to handle yaml or json, and will be automatically converted to json if yaml is pasted in.
- Create a Website using this new Website Starter
- Go to Settings -> Metadata, add set some course feature tags on your course site and make sure you can save
- Go to Resources and create a new resource.  Make sure you can add multiple course feature tags to your resource and save the resource
