### PR TITLE
mark extra_course_numbers as not required

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -123,7 +123,6 @@ collections:
           - label: "Extra Course Numbers (comma separated list)"
             name: "extra_course_numbers"
             widget: "string"
-            required: true
           - label: Course Image
             name: course_image
             widget: relation


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Extra course numbers were accidentally set as a required field when they shouldn't be.  This PR sets the field as not required.

#### How should this be manually tested?
- Paste the site config into a new Website Starter in your local instance of `ocw-studio` (or on RC). The Django admin field is equipped to handle yaml or json, and will be automatically converted to json if yaml is pasted in.
- Create a Website using this new Website Starter
- Go to Settings -> Metadata and make sure Extra Course Numbers is blank
- Verify that you can save the metadata
