### PR TITLE
add markdown course description to metadata

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -116,6 +116,9 @@ collections:
             name: "course_title"
             widget: "string"
             required: true
+          - label: "Course Description"
+            name: "course_description"
+            widget: "markdown"
           - label: "Primary Course Number"
             name: "primary_course_number"
             widget: "string"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/41

#### What's this PR do?
This PR adds the course description markdown field to the course metadata in the course starter

#### How should this be manually tested?
 - Copy and paste `ocw-course/ocw-studio.yaml` into a `WebsiteStarter` in a locally running instance of `ocw-studio` (or on RC)
 - Create a new site using this starter and go to the Course Metadata section
 - Enter some data into the course description and fill out the other required fields, make make sure you can save
