### PR TITLE
add nav menu widget to course starter

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -252,3 +252,17 @@ collections:
             display_field: title
             multiple: true
             website: ocw-www
+
+  - category: Settings
+    label: Menu
+    name: menu
+    files:
+      - file: config/_default/menus.yaml
+        name: navmenu
+        label: Navigation Menu
+        fields:
+          - {
+            "label": "Menu",
+            "name": "leftnav",
+            "widget": "menu",
+          }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/43

#### What's this PR do?
This PR adds a navigation menu widget to the course starter.  It is configured to produce a menu that will be compatible with the course theme in `ocw-hugo-themes`

#### How should this be manually tested?
 - Copy and paste the contents of `ocw-course/ocw-studio.yaml` into a `WebsiteStarter` config in either your locally running instance of `ocw-studio` or on RC
 - Create a `Website` using the `WebsiteStarter` you created above
 - Go to the Menu section and add a few menu items and verify you can save
