### PR TITLE
page not pages

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -3,7 +3,7 @@ root-url-path: courses
 collections:
   - category: Content
     folder: content/pages
-    label: Page
+    label: Pages
     name: page
     fields:
       - label: Title

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -4,7 +4,7 @@ collections:
   - category: Content
     folder: content/pages
     label: Page
-    name: pages
+    name: page
     fields:
       - label: Title
         name: title


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/51

#### What's this PR do?
When importing courses in `ocw-studio` using `import_ocw_course_sites`, the `type` on course sections is set to the constant value of `CONTENT_TYPE_PAGE` which at the time of writing is `page`. This PR changes the `name` property of the Pages collection in the course starter from `pages` to `page` so that when courses are imported and assigned the starter from this repo, everything lines up properly.

#### How should this be manually tested?
 - Spin up a local instance of `ocw-studio` or use RC for the steps below, and make sure you have AWS credentials for RC set in your env if you are using a local instance of studio
 - Copy and paste the contents of `ocw-course/ocw-studio.yaml` into a `WebsiteStarter` in OCW Studio's Django admin interface
 - On the OCW Studio instance, run `./manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter 15-401`
 - Browse to the instance of OCW Studio that you ran the import on, then click on the Pages collection and verify that you see imported pages
