### PR TITLE
use underscore instead of hyphen in image_alt

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -146,7 +146,7 @@ collections:
         condition: { field: filetype, equals: Image }
         fields:
           - label: ALT text
-            name: image-alt
+            name: image_alt
             widget: string
           - label: Caption
             name: caption


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/55

#### What's this PR do?
This PR simply changes "-" to "_" in the name property of the Image ALT field.

#### How should this be manually tested?
 - Load the course starter (`ocw-course/ocw-studio.yaml`) into an instance of `ocw-studio` and create a site
 - Add at least one image resource to the site and specify Image ALT
 - Publish this site and download the published markdown
 - Clone `ocw-hugo-themes` and add a layout at `course/layouts/resource/single.html` with the following content:
 ```
 <img src="{{ .Params.file }}" alt="{{ .Params.metadata.image-alt }}" />
 ```
 - Try and render the site using `hugo --themesDir /path/to/ocw-hugo-themes --config /path/to/ocw-hugo-projects/ocw-course/config.yaml`
