### PR TITLE
add json media types and outputs

### DIFF
--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -7,4 +7,12 @@ title: MIT OpenCourseWare
 caches:
   getjson:
     maxAge: 5m
+mediaTypes:
+  application/json:
+    suffixes:
+      - json
+outputs:
+  page:
+    - HTML
+    - JSON
 theme: ["base-theme", "www"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/63

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/167, we added JSON layouts to the `base-theme` and `www` themes.  These define a base JSON file for rendering a static API as well as a layout for instructor JSON API responses.  This PR adds the necessary configuration to `ocw-www/config.yaml` to support rendering JSON files in the Hugo output

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` on the `cg/instructors-static-api` branch
 - Read the readme if you've never worked with `ocw-hugo-themes` before
 - Spin up the webpack dev server locally by running `npm run start:site:webpack`
 - Clone https://github.com/mitodl/ocw-hugo-projects on this PR branch
 - Clone https://github.mit.edu/ocw-content-rc/ocw-www/ and open a terminal in the resulting folder
 - Run `hugo server --config /path/to/ocw-hugo-projects/ocw-www/config.yaml --themesDir /path/to/ocw-hugo-themes/`, replacing the example paths with the paths to your cloned repos
 - Pick an instructor in the source `ocw-www` data and visit your local dev site verifying that the instructor exists and data is returned, for example: http://localhost:1313/instructors/0a90e4c5-5f99-646e-cbfc-402250d8aba5/index.json
