### PR TITLE
Separate metadata sections for videos, images

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -90,7 +90,7 @@ collections:
           - 'Written Assignments with Examples'
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
-        name: metadata
+        name: image_metadata
         widget: object
         condition: { field: filetype, equals: Image }
         fields:
@@ -105,7 +105,7 @@ collections:
             widget: text
       # show the sections below only if the type of resource is "Video"
       - label: Video Metadata
-        name: metadata
+        name: video_metadata
         widget: object
         condition: {field: filetype, equals: Video}
         fields:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a bug where video metadata was always overwriting image metadata because of a shared name.

#### How should this be manually tested?
In ocw-studio, update the site config to match the changes here.
Create an image resource and a video resource, fill out metadata fields for each, and save. Reload each resource and verify the field values were saved.
