### PR TITLE
course_feature_tags->learningResourceType

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -40,8 +40,8 @@ collections:
       - label: File
         name: file
         widget: file
-      - label: "Course Feature Tags"
-        name: "course_feature_tags"
+      - label: "Learning Resource Types"
+        name: "learning_resource_types"
         widget: select
         multiple: true
         options:
@@ -226,8 +226,8 @@ collections:
               - 'Both'
               - 'Non Credit'
             widget: "select"
-          - label: "Course Feature Tags"
-            name: "course_feature_tags"
+          - label: "Learning Resource Types"
+            name: "learning_resource_types"
             widget: select
             multiple: true
             options:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-projects/issues/58

#### What's this PR do?
This pr replaces course_feature_tags with learning_resource_type in the ocw-course starter

#### How should this be manually tested?
1) Paste the site config into a new Website Starter in your local instance of ocw-studio
2) Create a Website using this new Website Starter
3) Create a resource for the website and set "Learning Resource Type". Verify that you can save the resource
