### PR TITLE
Add slug field for instructor

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -159,6 +159,7 @@ collections:
     folder: content/instructors
     label: Instructor
     name: instructor
+    slug: text_id
     fields:
       - label: First name
         name: first_name


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/pull/600

#### What's this PR do?
New instructors have a filename assigned to them using the instructor title. However we need to use the uuid as the filename so that ocw-hugo-themes can fetch instructor data when the website is built. This communicates that the `text_id` which contains the uuid should be used when creating the filename.
