### PR TITLE
add a description field to video galleries

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -21,6 +21,9 @@ collections:
     label: "Video Gallery"
     name: video_gallery
     fields:
+      - label: "Description"
+        name: "description"
+        widget: "markdown"
       - label: Videos
         name: videos
         widget: relation


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Starter changes tested in [`ocw-studio`](https://github.com/mitodl/ocw-studio)
- [ ] Theme updates
  - [ ] A PR with any necessary theme changes has been created in [`ocw-hugo-themes`](https://github.com/mitodl/ocw-hugo-themes), linked in your testing instructions
- [ ] Migrations
  - [ ] If data needs to be migrated in [`ocw-studio`](https://github.com/mitodl/ocw-studio), a PR has been created to do so

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/90

#### What's this PR do?
The new design for video galleries includes a description above the video cards.  This PR adds a field to the Video Gallery configuration in the `ocw-course` starter to add a description markdown field to the video gallery pages.

#### How should this be manually tested?
 - Spin up a local instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio) and ensure you are setup to publish sites to a test Github organization and Google drive integration is enabled
 - Visit http://localhost:8043/admin and create a new `WebsiteStarter` object and paste in the contents of `ocw-course/ocw-studio.yaml`
 - Visit http://localhost:8043/sites and create a new site using the starter you just created
 - Visit the metadata section and fill in the required fields
 - Visit the Resources section of your site in the site editor and go to the Google drive folder.  Upload a few short test videos and click "Sync With Google Drive."
 - Once your video resources have been created, go to the Video Galleries section and create one
 - Add your videos to the gallery and set a text description in the markdown field
 - Go to the Menu section and add a menu entry pointing to your video gallery
 - Save and publish your course
 - Visit your test organization on Github and find your published course
 - Clone that course locally
 - Clone [`ocw-hugo-themes`](https://github.com/mitodl/ocw-hugo-themes) on the `cg/video-gallery-description` branch
 - In your `.env` there, set `COURSE_CONTENT_PATH` to the parent folder of your cloned site and `OCW_TEST_COURSE` to the name of the folder containing your site
 - Start your site with `npm run start:course` and browse to your video gallery
 - Ensure that the description renders above the video cards
