### PR TITLE
ignore errors getting json during course builds

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -5,3 +5,4 @@ languageCode: en-us
 relativeURLs: false
 title: MIT OpenCourseWare
 theme: ["base-theme", "course"]
+ignoreErrors: ["error-remote-getjson"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/95

#### What's this PR do?
As of the time of writing, the sites at https://ocwnext-rc.odl.mit.edu and https://ocwnext.odl.mit.edu are built using a custom EC2 server and a monolithic bash script that pulls down all the legacy OCW course data from S3 and processes it with [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo).  Then, each of those courses are built using [`ocw-hugo-themes`](https://github.com/mitodl/ocw-hugo-themes) along with the Hugo config from this repo located at `ocw-course/config.yaml`.

In https://github.com/mitodl/ocw-hugo-themes/pull/186, we changed [`ocw-hugo-themes`](https://github.com/mitodl/ocw-hugo-themes) to source instructors displayed under course info from a static API, defined in `STATIC_API_URL`.  This static API is expected to be a pubilshed `ocw-www` site containing all the instructors referenced by course sites.  On these monolithic EC2 based build servers that are building the current OCW Next sites, they are directly using the latest course data exported from the legacy Plone based system to build courses which sometimes includes new instructors.  The main problem here is that those new instructors don't yet exist in the static API, they need to be imported into [`ocw-studio`](https://github.com/mitodl/ocw-studio) first and published, but that can't happen if the EC2 build fails because the last step of the build is to upload that converted data from [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo) to S3 for [`ocw-studio`](https://github.com/mitodl/ocw-studio) to import.

This PR sets `ignoreErrors: ["error-remote-getjson"]` in the `ocw-course` Hugo config so that a hard error is not thrown when an instructor is missing and cannot be fetched from the static JSON API.  This is a temporary solution to unblock releases in the `ocw-hugo-themes` repo, which currently uses the EC2 builds to verify commits.  Once the transition has been made to edit content in [`ocw-studio`](https://github.com/mitodl/ocw-studio), we can safely remove this hack.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes`, `ocw-hugo-projects` (on this PR branch) and `ocw-to-hugo` and make sure your `ocw-to-hugo` is set up to download courses from S3
 - Process the example courses in `ocw-to-hugo` with `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download --rm`
 - Pick one of the example courses, and open the course data template at `data/course.json`
 - Change any of the instructor UUID's to a random UUID (you can generate one at https://www.uuidgenerator.net/
 - In `ocw-hugo-themes` in your `.env` file, set:
   - `STATIC_API_BASE_URL=https://ocw-live-production.global.ssl.fastly.net/`
   - `COURSE_HUGO_CONFIG_PATH=/path/to/ocw-hugo-projects/ocw-course/config.yaml`
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output/`
   - `OCW_TEST_COURSE=<folder name of the course you modified>`
 - Run `npm run start:course`
 - Verify that the course spun up with no errors, and browse to http://localhost:3000
 - If your course had multiple instructors, you should see any that exist in the static API, otherwise you should just see a blank next to "Instructor(s)"
