### PR TITLE
hugo 0.91 security updates

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -9,4 +9,10 @@ ignoreErrors: ["error-remote-getjson"]
 security:
   funcs:
     getenv:
-    - .*
+    - ^HUGO_
+    - GTM_ACCOUNT_ID
+    - RESOURCE_BASE_URL
+    - STATIC_API_BASE_URL
+    - OCW_STUDIO_BASE_URL
+    - OCW_IMPORT_STARTER_SLUG
+    - COURSE_BASE_URL

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -6,3 +6,7 @@ relativeURLs: false
 title: MIT OpenCourseWare
 theme: ["base-theme", "course"]
 ignoreErrors: ["error-remote-getjson"]
+security:
+  funcs:
+    getenv:
+    - .*

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -19,4 +19,10 @@ theme: ["base-theme", "www"]
 security:
   funcs:
     getenv:
-    - .*
+    - ^HUGO_
+    - GTM_ACCOUNT_ID
+    - RESOURCE_BASE_URL
+    - STATIC_API_BASE_URL
+    - OCW_STUDIO_BASE_URL
+    - OCW_IMPORT_STARTER_SLUG
+    - COURSE_BASE_URL

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -16,3 +16,7 @@ outputs:
     - HTML
     - JSON
 theme: ["base-theme", "www"]
+security:
+  funcs:
+    getenv:
+    - .*


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/105

#### What's this PR do?
In Hugo 0.91, there has been an update to the default security configuration:

https://gohugo.io/about/security-model/#security-policy

This is a breaking change that throws a hard error whenever Hugo tries to access an environment variable that isn't explicitly allowed.  This PR adds the env variables that we use in `ocw-hugo-themes` explicitly to the Hugo configurations stored in this repo.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes`
 - Clone `ocw-hugo-projects`
 - Clone https://github.mit.edu/ocw-content-rc/ocw-www
 - Run `npm run build -- /path/to/ocw-www /path/to/ocw-hugo-projects/ocw-www/config.yaml`
 - Ensure that the build completes with no errors

