### PR TITLE
add config for course collections to ocw-www

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -29,6 +29,24 @@ collections:
         sortable: true
 
   - category: Content
+    folder: content/course_collections
+    label: "Course Collections"
+    name: "course_collections"
+    fields:
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Description
+        name: description
+        widget: markdown
+
+      - label: Courses
+        name: courses
+        widget: website-collection
+
+  - category: Content
     folder: content/promos
     label: Promo
     name: promos


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #101
related to https://github.com/mitodl/ocw-studio/issues/885 

🚧 **blocked until https://github.com/mitodl/ocw-studio/pull/888 merges** 🚧 

#### What's this PR do?

This PR adds a new content type to the ocw-www config file which defines a course collection using the new `website-collection` widget type introduced in https://github.com/mitodl/ocw-studio/pull/888.

#### How should this be manually tested?

After https://github.com/mitodl/ocw-studio/pull/888 merges you should be able to use this ocw-www config in your dev environment to see a UI that lets you create collections of websites.