### PR TITLE
add output type for content map, add that to the homepage

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -11,9 +11,14 @@ outputFormats:
     mediaType: "application/json"
     baseName: "data"
     isPlainText: true
+  contentmap:
+    mediaType: "application/json"
+    baseName: "content_map"
+    isPlainText: true
 outputs:
   home:
     - coursedata
+    - contentmap
     - HTML
   page:
     - coursedata


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

for https://github.com/mitodl/ocw-hugo-themes/issues/279

#### What's this PR do?

This adds a `content_map` output type

#### How should this be manually tested?

it can be tested as part of testing https://github.com/mitodl/ocw-hugo-themes/pull/400
