### PR TITLE
feat: 3 new learning resource types added

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -324,6 +324,9 @@ collections:
               - 'Workshop Videos'
               - 'Written Assignments'
               - 'Written Assignments with Examples'
+              - 'Introductory'
+              - 'Self-Learner Complete'
+              - 'Zero Textbook Cost'
           - label: Instructors
             name: instructors
             widget: relation


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/121

#### What's this PR do?
- Adds three new options to the `Learning Resource Types` for courses:
     1. Introductory
     2. Self-Learner Complete
     3. Zero Textbook Cost

#### How should this be manually tested?
- Go to the admin (django admin) site of `ocw-studio`: either setup it locally or use RC.
- Add a new `WebsiteStarter`
- Convert `ocw-course/ocw-studio.yaml` to JSON format and paste it into the config field for this new WebsiteStarter and then save it.
- Verify that the config is validated and `WebsiteStarter` is successfully saved.

