### PR TITLE
fix: adding markup config so html in content is rendered

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -36,3 +36,7 @@ security:
     - OCW_STUDIO_BASE_URL
     - OCW_IMPORT_STARTER_SLUG
     - COURSE_BASE_URL
+markup:
+  goldmark:
+    renderer:
+      unsafe: true


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/441

#### What's this PR do?
- `Goldmark` is the default renderer of `Hugo` and by default it has `unsafe: false`, which means that it will not render any raw HTML in the content.
- This PR, sets `unsafe: true` so `Goldmark` can render the raw HTML, though making `unsafe = true` sounds a bit scary but I don't think it will make the site unsafe. However, it is recommended to make sure that this will not cause any security vulnerability.  

#### How should this be manually tested?
- Checkout to this branch.
- Build and run this [course](https://ocw-published.odl.mit.edu/courses/7-01sc-fundamentals-of-biology-fall-2011/) locally.
- Go to this [page](https://ocw-published.odl.mit.edu/courses/7-01sc-fundamentals-of-biology-fall-2011/pages/biochemistry/macromolecules-lipids-carbohydrates-nucleic-acid/) and make sure that the content is rendering and the section is not blank like shown in the issue.

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/93309234/154100808-747efdea-0d5d-45e7-b4b9-ed4de5db63c8.png)

After:
![image](https://user-images.githubusercontent.com/93309234/154100748-813516ed-9260-4a58-9ef4-aa40af8d28a1.png)
