### PR TITLE
add draft to the types of content that need it

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -6,6 +6,11 @@ collections:
     label: Pages
     name: page
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         widget: string
@@ -21,9 +26,20 @@ collections:
     label: "Video Gallery"
     name: video_gallery
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
       - label: "Description"
         name: "description"
         widget: "markdown"
+
       - label: Videos
         name: videos
         widget: relation
@@ -41,6 +57,11 @@ collections:
     label: Resources
     name: resource
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         required: true

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -10,6 +10,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -30,6 +31,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -61,6 +63,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -6,6 +6,11 @@ collections:
     label: Page
     name: pages
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         widget: string
@@ -20,6 +25,16 @@ collections:
     label: "Resource Collections"
     name: "resource_collections"
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
       - label: Description
         name: description
         widget: markdown
@@ -37,6 +52,11 @@ collections:
     label: "Course Collections"
     name: "course_collections"
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         widget: string
@@ -55,6 +75,11 @@ collections:
     label: Promo
     name: promos
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         widget: string
@@ -90,6 +115,11 @@ collections:
     label: Notification
     name: notifications
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        
       - label: Title
         name: title
         widget: string
@@ -110,6 +140,11 @@ collections:
     label: Testimonial
     name: testimonials
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         widget: string
@@ -153,6 +188,11 @@ collections:
     label: Resources
     name: resource
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: Title
         name: title
         required: true
@@ -196,6 +236,11 @@ collections:
     name: instructor
     slug: text_id
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+
       - label: First name
         name: first_name
         widget: string

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -10,6 +10,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -29,6 +30,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -56,6 +58,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -79,6 +82,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -119,6 +123,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
         
       - label: Title
         name: title
@@ -144,6 +149,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -192,6 +198,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -240,6 +247,7 @@ collections:
         name: draft
         required: true
         widget: boolean
+        help_text: Enable this setting to prevent publishing in production
 
       - label: First name
         name: first_name


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/933

#### What's this PR do?
This PR adds a boolean `draft` field to items in the `Content` category in both the `ocw-www` and `ocw-course` starter configurations, defaulting to false.  When set to true, this will automatically set `draft: true` in the front matter of any content being published, telling Hugo to not render the page or any JSON data.

#### How should this be manually tested?
 - Spin up a local instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio), making sure you follow the instructions to set up your own Github organization for testing
 - Create the `ocw-www` and `ocw-course` starters if you don't have them already and update their configuration with the ones from this branch
 - Create a test site or open an existing one
 - Create two test pages, one with `draft` set to `false`, and the other with `draft` set to `true`
 - Publish the site to your test org and then clone the output
 - Clone `ocw-hugo-themes` if you don't have it already and set it up to spin up your test site locally
 - Spin up the test site and verify that your page with `draft: true` is not reachable, but your page with `draft: false` is
