### PR TITLE
feat: learning resource type: instructor insights added

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -81,6 +81,7 @@ collections:
           - Exams
           - 'Exams with Solutions'
           - 'Image Gallery'
+          - 'Instructor Insights'
           - Labs
           - 'Lecture Audio'
           - 'Lecture Notes'
@@ -293,6 +294,7 @@ collections:
               - Exams
               - 'Exams with Solutions'
               - 'Image Gallery'
+              - 'Instructor Insights'
               - Labs
               - 'Lecture Audio'
               - 'Lecture Notes'


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/115

#### What's this PR do?
- Adds Learning Resource type: `Instructor Insights` for courses and resources

#### How should this be manually tested?
- Go to the admin (django admin) site of `ocw-studio`: either setup it up locally or use RC.
- Add a new `WebsiteStarter`
- Paste the configuration in `ocw-course/ocw-studio.yaml` into the config field for this new WebsiteStarter and then save it.
- Verify that the config is validated and `WebsiteStarter` is successfully saved.
- Create a new site with this starter
- Go to site's metadata and resources and verify that Learning Resource type has `Instructor Insights`

#### Screenshots
<img width="516" alt="image" src="https://user-images.githubusercontent.com/93309234/154489139-fcda016b-5a88-4e2f-b2b3-031bf0d6664a.png">

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/93309234/154489203-ba2921aa-aa49-44e2-951e-2f4db8412a07.png">

