### PR TITLE
remove attach; add link + embed

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -14,7 +14,12 @@ collections:
       - label: Body
         name: body
         widget: markdown
-        attach: resource
+        link:
+          - resource
+          - page
+        embed:
+          - resource
+          - page
 
   - category: Content
     folder: content/video_galleries

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -14,6 +14,9 @@ collections:
       - label: Body
         name: body
         widget: markdown
+        link:
+          - course_collections
+          - resource_collections
    
   - category: Content
     folder: content/resource_collections


### PR DESCRIPTION
The "link" and "embed" keys control what types of content can be linked/embedded in OCW Studio's markdown editor.

#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/1038

#### What's this PR do?
Adds link/embed keys for controlling which types of content can be linked/embedded in Studio's markdown editor.

#### How should this be manually tested?
See https://github.com/mitodl/ocw-studio/pull/1055
