### PR TITLE
do not allow embedding pages

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -19,7 +19,6 @@ collections:
           - page
         embed:
           - resource
-          - page
 
   - category: Content
     folder: content/video_galleries


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes a bug from https://github.com/mitodl/ocw-hugo-projects/pull/128

#### What's this PR do?
Removes "Pages" from the embed list

#### How should this be manually tested?
Use the updated config in OCW studio and check that pages no longer appear in the embed list.
