### PR TITLE
help not help_text

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -10,7 +10,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -35,7 +35,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -67,7 +67,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -10,7 +10,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -33,7 +33,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -61,7 +61,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -85,7 +85,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -126,7 +126,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
         
       - label: Title
         name: title
@@ -152,7 +152,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -201,7 +201,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: Title
         name: title
@@ -250,7 +250,7 @@ collections:
         name: draft
         required: true
         widget: boolean
-        help_text: Enable this setting to prevent publishing in production
+        help: Enable this setting to prevent publishing in production
 
       - label: First name
         name: first_name


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/125, we added the Draft setting for all types of content that support it.  `help_text` was mistakenly set on these properties to add a description to the UI about the field, when the field it should have gone in is simply `help`.  This PR corrects that by moving the help text to `help`.

#### How should this be manually tested?
Make sure you can copy & paste `ocw-course/ocw-studio.yml` and `ocw-www/ocw-studio.yml` into `ocw-studio`'s Django admin in the configuration field for a `WebsiteStarter` without error.  Go to a site using this starter afterward and make sure you see "Enable this setting to prevent publishing in production" under the draft settings.
