### PR TITLE
make video_gallery markdown body editable

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -42,9 +42,14 @@ collections:
         widget: string
         required: true
 
-      - label: "Description"
-        name: "description"
-        widget: "markdown"
+      - label: Body
+        name: body
+        widget: markdown
+        link:
+          - resource
+          - page
+        embed:
+          - resource
 
       - label: Videos
         name: videos


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets? #138

#### What's this PR do?
Makes video_gallery markdown bodies editable 

I included embedding/linking because that seems desirable?

#### How should this be manually tested?
1. Paste the new config into `ocw-course` website starter in local admin panel
2. Check that the markdown body shows up at http://chris.ocw-studio.odl.local:8043/sites/res-9-003-brains-minds-and-machines-summer-course-summer-2015/type/video_gallery/edit/e1619dcf-4933-8ee6-8458-d20fd651289a/ ... but with your version of `chris.ocw...`.
3. Edit the markdown and save

#### Screenshots (if appropriate)

<img width="1876" alt="Screen Shot 2022-03-07 at 2 34 13 PM" src="https://user-images.githubusercontent.com/9010790/157105030-4dfa2a6e-41c3-4bd3-8f27-8e59b7f5e239.png">

