### PR TITLE
add configuration for course list, collection

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -53,9 +53,9 @@ collections:
         sortable: true
 
   - category: Content
-    folder: content/course_collections
-    label: "Course Collections"
-    name: "course_collections"
+    folder: content/course-lists
+    label: "Course Lists"
+    name: "course-lists"
     fields:
       - label: Draft
         name: draft
@@ -75,6 +75,37 @@ collections:
       - label: Courses
         name: courses
         widget: website-collection
+
+  - category: Content
+    folder: content/collections
+    label: "Course Collections"
+    name: course-collection
+    fields:
+      - label: "Description"
+        name: "description"
+        widget: "markdown"
+      - label: Cover Image
+        name: cover-image
+        widget: relation
+        collection: resource
+        display_field: title
+        multiple: false
+        filter:
+          field: "filetype"
+          filter_type: "equals"
+          value: "Image"
+
+      - label: Featured Courses
+        name: featured-courses
+        widget: website-collection
+
+      - label: Course Collections
+        name: collections
+        widget: relation
+        multiple: true
+        collection: course-lists
+        display_field: title
+        sortable: true
 
   - category: Content
     folder: content/promos


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #142 

#### What's this PR do?

This PR adds configuration for a course collection gallery content type. This is basically a "collection of collections," and will render w/ a description and then the collections which have been added to it.

The idea is that this will be a good way to represent some of the more complicated collections that currently exist on production OCW, where there are different sections and whatnot. Basically, course authors would author each of those sections as a separate course collection, with a description and a list of courses, and then add them to a course collection gallery in the desired order.

#### How should this be manually tested?

You could paste this config into Studio and make sure it works properly.