### PR TITLE
add body text editing to resources

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -91,7 +91,7 @@ collections:
         embed:
           - resource
         help: >
-          The body of the resource page, displayed below the page title 
+          The body of the resource page, displayed below the page title
           but above the resource metadata / embed / download button
       - label: Resource Type
         name: resourcetype

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -90,6 +90,7 @@ collections:
           - page
         embed:
           - resource
+        help: The body of the resource page, displayed below the page title but above the resource metadata / embed / download button
       - label: Resource Type
         name: resourcetype
         required: true

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -91,8 +91,8 @@ collections:
         embed:
           - resource
         help: >
-          The body of the resource page, displayed below the page title
-          but above the resource metadata / embed / download button
+          The body of the resource page, displayed below
+          the page title and above the resource
       - label: Resource Type
         name: resourcetype
         required: true

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -90,7 +90,9 @@ collections:
           - page
         embed:
           - resource
-        help: The body of the resource page, displayed below the page title but above the resource metadata / embed / download button
+        help: >
+          The body of the resource page, displayed below the page title 
+          but above the resource metadata / embed / download button
       - label: Resource Type
         name: resourcetype
         required: true

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -82,6 +82,14 @@ collections:
         name: description
         widget: markdown
         minimal: true
+      - label: Body
+        name: body
+        widget: markdown
+        link:
+          - resource
+          - page
+        embed:
+          - resource
       - label: Resource Type
         name: resourcetype
         required: true


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/153

#### What's this PR do?
This PR adds markdown body editing to resources.  The body will be used to write descriptions for videos and other resources to be displayed on the resource page rendered by Hugo during the site build.

#### How should this be manually tested?
 - Spin up a local instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio) and ensure you have a test Github org set up as described in the readme
 - Create a new `WebsiteStarter` or update an existing one with the contents of `ocw-course/ocw-studio.yaml` from this branch
 - Choose one of these 3 options:
   - Make sure your `ocw-studio` is set up with Google Drive credentials from RC and upload a video to your course, then sync
   - Import a course using `import_ocw_course_sites` that has video resources
   - Go into Django admin and manually create a `WebsiteContent` object of type `resource` and `metadata.resource_type = Video`
 - Go to the editing UI for your site and bring up the video under Resources, add some text under the body field and publish your site
 - Go to your Github test org and verify that you see the text published in the markdown body
