### PR TITLE
add youtube description field and help text

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -78,6 +78,7 @@ collections:
         name: title
         required: true
         widget: string
+        help: If this is a video, this will be published as the YouTube title
       - label: Description
         name: description
         widget: markdown
@@ -181,10 +182,14 @@ collections:
         name: video_metadata
         widget: object
         condition: { field: resourcetype, equals: Video }
+        help: These fields will be published to YouTube
         fields:
           - label: Youtube ID
             name: youtube_id
             widget: string
+          - label: Youtube Description
+            name: youtube_description
+            widget: text
           - label: Youtube Speakers
             name: video_speakers
             widget: string
@@ -195,6 +200,7 @@ collections:
         name: video_files
         widget: object
         condition: { field: resourcetype, equals: Video }
+        help: These fields will be published to YouTube
         fields:
           - label: Video Thumbnail URL
             name: video_thumbnail_file

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -200,7 +200,9 @@ collections:
         name: video_files
         widget: object
         condition: { field: resourcetype, equals: Video }
-        help: These fields will be published to YouTube
+        help: >
+          Internal YouTube fields, don't edit
+          unless you know what you're doing
         fields:
           - label: Video Thumbnail URL
             name: video_thumbnail_file


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-projects/issues/156
Closes https://github.com/mitodl/ocw-hugo-projects/issues/152

#### What's this PR do?
Currently, YouTube descriptions are sourced from the `description` field on a resource, which is a markdown field.  This isn't ideal for a couple reasons; one being that the resource description doesn't necessarily match the description desired for YouTube but also the YouTube description does not even support markdown.  This PR adds a new raw text field to the `ocw-course` starter explicitly for YouTube descriptions under `video_metadata.youtube_description`.  Help text was also added on the `title` property, `video_metadata` and `video_files` sections stating that those fields will be published to YouTube.

#### How should this be manually tested?
 - Spin up a local instance of [`ocw-studio`](https://github.com/mitodl/ocw-studio) and ensure you have a test Github org set up as described in the readme
 - Create a new `WebsiteStarter` or update an existing one with the contents of `ocw-course/ocw-studio.yaml` from this branch
 - Choose one of these 3 options:
   - Make sure your `ocw-studio` is set up with Google Drive credentials from RC and upload a video to your course, then sync
   - Import a course using `import_ocw_course_sites` that has video resources
   - Go into Django admin and manually create a `WebsiteContent` object of type `resource` and `metadata.resource_type = Video`
 - Go to the editing UI for your site and bring up the video under Resources, add some text under the YouTube Description field and publish your site
 - Go to your Github test org and verify that you see the text published in the `video_metadata.youtube_description` field
