### PR TITLE
promo image required

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -144,6 +144,7 @@ collections:
         widget: relation
         collection: resource
         display_field: title
+        required: true
         multiple: false
         min: 1
         max: 1


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/147

#### What's this PR do?
- Sets `Required=true` for promo images

#### How should this be manually tested?
- Copy the config in `ocw-www/ocw-studio.yaml`.
- Go to `ocw-studio`, either RC or your local setup.
- In `ocw-studio` admin: Paste this config in any website starter for which there's a course.
- In `ocw-studio` sites: Open the course whose starter config has been updated.
- Try adding a new promo and verify that now promo image is required. 

#### Screenshots (if appropriate)
<img width="526" alt="image" src="https://user-images.githubusercontent.com/93309234/163570043-1591065d-5a01-413e-b003-124607dc662f.png">

