### PR TITLE
feat: embed resource added for ocw www

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -23,6 +23,8 @@ collections:
         link:
           - course_collections
           - resource_collections
+        embed: 
+          - resource
 
   - category: Content
     folder: content/resource_collections

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -3,8 +3,8 @@ root-url-path: ""
 collections:
   - category: Content
     folder: content/pages
-    label: Page
-    name: pages
+    label: Pages
+    name: page
     fields:
       - label: Draft
         name: draft
@@ -95,7 +95,7 @@ collections:
         display_field: title
         multiple: false
         filter:
-          field: "filetype"
+          field: "resourcetype"
           filter_type: "equals"
           value: "Image"
 
@@ -153,7 +153,7 @@ collections:
         min: 1
         max: 1
         filter:
-          field: "filetype"
+          field: "resourcetype"
           filter_type: "equals"
           value: "Image"
 
@@ -220,7 +220,7 @@ collections:
         min: 1
         max: 1
         filter:
-          field: "filetype"
+          field: "resourcetype"
           filter_type: "equals"
           value: "Image"
 
@@ -268,7 +268,7 @@ collections:
       - label: Image Metadata
         name: metadata
         widget: object
-        condition: { field: filetype, equals: Image }
+        condition: { field: resourcetype, equals: Image }
         fields:
           - label: ALT text
             name: image_alt

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -23,7 +23,7 @@ collections:
         link:
           - course_collections
           - resource_collections
-        embed: 
+        embed:
           - resource
 
   - category: Content

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -23,6 +23,8 @@ collections:
         link:
           - course_collections
           - resource_collections
+          - resource
+          - page
         embed:
           - resource
 
@@ -249,8 +251,8 @@ collections:
         name: description
         widget: markdown
         minimal: true
-      - label: File Type
-        name: filetype
+      - label: Resource Type
+        name: resourcetype
         required: true
         widget: select
         options:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/160

#### What's this PR do?
- Adds `resource embed` in ocw-www studio config 
- Adds `resource` and `page` link in ocw-www studio config
- Changes `name: filetype` to `name: resourcetype` for resources in in ocw-www studio config

#### How should this be manually tested?
- Checkout this branch
- Copy the config
- Either in studio RC or in studio local setup, paste this config in the starter of `ocw-www`
- Go to `ocw-www` in `studio/sites` and add/edit a page 
- Verify that `Embed Resource` button is now there in editor.
- Verify that all the resources are being shown when you try to embed a resource.
- Verify that resource and page are there when you add a link 

#### Screenshots (if appropriate)
<img width="870" alt="image" src="https://user-images.githubusercontent.com/93309234/164082726-8a3bd49b-2299-4790-8b94-e7dfd77f5304.png">

<img width="745" alt="image" src="https://user-images.githubusercontent.com/93309234/164082753-1c88a2c2-30b8-489d-a1ec-87d27af3a293.png">

