### PR TITLE
use markdown widget on captions and credits

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -185,9 +185,11 @@ collections:
           - label: Caption
             name: caption
             widget: markdown
+            minimal: true
           - label: Credit
             name: credit
             widget: markdown
+            minimal: true
       # show the sections below only if the type of resource is "Video"
       - label: Video Metadata
         name: video_metadata

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -184,10 +184,10 @@ collections:
             widget: string
           - label: Caption
             name: caption
-            widget: string
+            widget: markdown
           - label: Credit
             name: credit
-            widget: text
+            widget: markdown
       # show the sections below only if the type of resource is "Video"
       - label: Video Metadata
         name: video_metadata


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/47

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/270, we set up the course theme to pass image captions and credits through `.RenderString` so they would be processed as markdown.  This PR changes the image metadata caption and credit fields in the `ocw-course` starter to use the markdown widget instead of simply being text.

#### How should this be manually tested?
 - Copy and paste the config into your local instance of `ocw-studio`
 - Find or create an image resource in a site and edit it
 - Put some text into the caption and credit fields and make sure to use components that would render as markdown like title, basic links, italics, bold, etc.
 - Publish your site and make sure that markdown is rendered in the front matter for this resources in the proper place
