### PR TITLE
add mit-fields starter

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -1,0 +1,28 @@
+---
+baseUrl: "/"
+enableRobotsTXT: true
+languageCode: en-us
+relativeURLs: false
+title: MIT Fields
+caches:
+  getjson:
+    maxAge: 5m
+mediaTypes:
+  application/json:
+    suffixes:
+      - json
+outputs:
+  page:
+    - HTML
+    - JSON
+theme: ["base-theme", "fields"]
+security:
+  funcs:
+    getenv:
+      - ^HUGO_
+      - GTM_ACCOUNT_ID
+      - RESOURCE_BASE_URL
+      - STATIC_API_BASE_URL
+      - OCW_STUDIO_BASE_URL
+      - OCW_IMPORT_STARTER_SLUG
+      - COURSE_BASE_URL

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -15,6 +15,7 @@ collections:
           - label: Description
             name: description
             widget: markdown
+            minimal: true
           - collection: resource
             display_field: title
             filter:

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -18,7 +18,7 @@ collections:
           - collection: resource
             display_field: title
             filter:
-              field: filetype
+              field: resourcetype
               filter_type: equals
               value: Image
             label: "Cover Image"
@@ -68,7 +68,7 @@ collections:
         widget: markdown
         minimal: true
       - label: Resource Type
-        name: headless
+        name: resourcetype
         widget: hidden
         default: Image
       - label: Mime Type

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -1,0 +1,57 @@
+---
+collections:
+  - category: Content
+    label: Field
+    name: field
+    files:
+      - file: content/field
+        label: Field
+        name: field_home
+        fields:
+          - label: Title
+            name: title
+            widget: string
+            required: true
+          - label: Description
+            name: description
+            widget: markdown
+          - collection: resource
+            display_field: title
+            filter:
+              field: filetype
+              filter_type: equals
+              value: Image
+            label: "Cover Image"
+            multiple: false
+            name: cover-image
+            widget: relation
+          - collection: subfield
+            display_field: title
+            label: "Featured Courses List"
+            multiple: false
+            name: featured-courses
+            sortable: false
+            widget: relation
+          - collection: subfield
+            display_field: title
+            label: Subfields
+            multiple: true
+            name: subfields
+            sortable: true
+            widget: relation
+  - category: Content
+    folder: content/subfields
+    label: Subfields
+    name: subfield
+    fields:
+      - label: Title
+        name: title
+        required: true
+        widget: string
+      - label: Description
+        name: description
+        widget: markdown
+      - label: Courses
+        name: courses
+        widget: website-collection
+root-url-path: ""

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -54,4 +54,4 @@ collections:
       - label: Courses
         name: courses
         widget: website-collection
-root-url-path: ""
+root-url-path: fields

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -54,4 +54,56 @@ collections:
       - label: Courses
         name: courses
         widget: website-collection
+  - category: Content
+    folder: content/resources
+    label: Images
+    name: resource
+    fields:
+      - label: Title
+        name: title
+        required: true
+        widget: string
+      - label: Description
+        name: description
+        widget: markdown
+        minimal: true
+      - label: Resource Type
+        name: headless
+        widget: hidden
+        default: Image
+      - label: Mime Type
+        name: file_type
+        widget: hidden
+      - label: File
+        name: file
+        widget: file
+      - label: License
+        name: license
+        options:
+          - label: CC-BY-NC-SA
+            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
+          - label: CC-BY
+            value: https://creativecommons.org/licenses/by/4.0/
+          - label: CC-BY-NC
+            value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: public domain
+            value: https://creativecommons.org/publicdomain/zero/1.0/
+        widget: select
+        default: https://creativecommons.org/licenses/by-nc-sa/4.0/
+        required: true
+      - label: Image Metadata
+        name: image_metadata
+        widget: object
+        fields:
+          - label: ALT text
+            name: image-alt
+            widget: string
+          - label: Caption
+            name: caption
+            widget: markdown
+            minimal: true
+          - label: Credit
+            name: credit
+            widget: markdown
+            minimal: true
 root-url-path: fields

--- a/mit-fields/ocw-studio.yaml
+++ b/mit-fields/ocw-studio.yaml
@@ -27,7 +27,7 @@ collections:
             widget: relation
           - collection: subfield
             display_field: title
-            label: "Featured Courses List"
+            label: "Featured Courses"
             multiple: false
             name: featured-courses
             sortable: false


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/167

#### What's this PR do?
This PR adds the new `mit-fields` starter definition and Hugo config.  It allows creation of websites in `ocw-studio` that will utilize the `fields` theme in `ocw-hugo-themes`.

#### How should this be manually tested?
 - This starter has already been manually added to `ocw-studio-rc` with the id `mit-fields`
 - Create a site using the `mit-fields` starter
 - Add some Subfields and add courses and descriptions to them
 - Go to the images section and upload a cover image
 - Visit the Fields section and fill out the data, making sure you set a featured course list as well as adding multiple Subfields as well as set the cover image
 - Publish your site and view it once publishing is complete, making sure everything looks as expected based on the screenshots in this PR: https://github.com/mitodl/ocw-hugo-themes/pull/670

#### Any background context you want to provide?
This is mostly a proof of concept that we want to get out the door so the team can try making these fields sites to see if they fit their needs for what they're trying to accomplish.  The goal here isn't to agonize over the details at the moment, just to make sure everything works and doesn't break anything else.
