### PR TITLE
make legacy uid hidden

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -731,7 +731,7 @@ collections:
                 Higher Education: []
           - label: "Legacy UID"
             name: "legacy_uid"
-            widget: "string"
+            widget: "hidden"
 
   - category: Settings
     label: Menu


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/1254

#### What's this PR do?
Makes legacy_uid uneditable

#### How should this be manually tested?
This should be tested with https://github.com/mitodl/ocw-studio/pull/1304

Update the  ocw-course starter on https://ocw-studio-rc.odl.mit.edu to the starter in this pr. 
Delete the legacy_uid from the metadata for an imported course through the admin ui. 
Run `heroku run python manage.py -a ocw-studio-rc import_ocw_course_sites -b ocw-to-hugo-output-qa --filter <course-slug>` to verify that the legacy_uid field is repopulated in the metadata and set to what it was before. 
Go to the metadata page in the course editing ui. Verify that legacy uid is not an editable field
