### PR TITLE
add SITEMAP_DOMAIN to the list of allowed env variables

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -26,3 +26,4 @@ security:
       - OCW_STUDIO_BASE_URL
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
+      - SITEMAP_DOMAIN

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -36,6 +36,7 @@ security:
       - OCW_STUDIO_BASE_URL
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
+      - SITEMAP_DOMAIN
 markup:
   highlight:
     style: colorful

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -26,3 +26,4 @@ security:
       - OCW_STUDIO_BASE_URL
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
+      - SITEMAP_DOMAIN


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/issues/673

#### What's this PR do?
This PR adds `SITEMAP_DOMAIN` to the list of allowed env variables that can be utilized in the `ocw-course` and `ocw-www` Hugo configurations.  This is necessary for coming changes to the sitemap layouts in `ocw-hugo-themes` that will construct a fully qualified URL for use in the url locations contained within.

#### How should this be manually tested?
This PR should be tested in conjunction with https://github.com/mitodl/ocw-hugo-themes/pull/674
