### PR TITLE
add sitemap_index outputFormat to ocw-www

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -20,6 +20,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL
       - STATIC_API_BASE_URL

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -30,13 +30,13 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL
       - STATIC_API_BASE_URL
       - OCW_STUDIO_BASE_URL
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
-      - SITEMAP_DOMAIN
 markup:
   highlight:
     style: colorful

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -37,6 +37,7 @@ security:
       - OCW_STUDIO_BASE_URL
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
+      - SITEMAP_DOMAIN
 markup:
   highlight:
     style: colorful

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -12,14 +12,22 @@ mediaTypes:
     suffixes:
       - json
 outputs:
+  home:
+    - sitemapIndex
   page:
     - HTML
     - JSON
+outputFormats:
+  sitemapIndex:
+    baseName: sitemap_index
+    isPlainText: true
+    mediaType: "application/xml"
 theme: ["base-theme", "www"]
 security:
   funcs:
     getenv:
       - ^HUGO_
+      - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL
       - STATIC_API_BASE_URL

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -13,13 +13,13 @@ mediaTypes:
       - json
 outputs:
   home:
-    - sitemapIndex
+    - wwwSitemap
   page:
     - HTML
     - JSON
 outputFormats:
-  sitemapIndex:
-    baseName: sitemap_index
+  wwwSitemap:
+    baseName: sitemap-www
     isPlainText: true
     mediaType: "application/xml"
 theme: ["base-theme", "www"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/issues/673

#### What's this PR do?
This PR adds a new `outputFormat` definition to the `ocw-www` Hugo configuration called `sitemapIndex` and assigns it to the `home` kind.  What this does is ensure that when an xml template is defined for the `home` page in a site using the `ocw-www` theme, it will be used to generate a `sitemap_index.xml` file.  This file acts as an index for large sites with multiple sitemaps.  More info can be found [here](https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps).

#### How should this be manually tested?
Tested as part of https://github.com/mitodl/ocw-hugo-themes/pull/679
