### PR TITLE
explicitly add back default output formats for the ocw-www home page

### DIFF
--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -13,6 +13,8 @@ mediaTypes:
       - json
 outputs:
   home:
+    - HTML
+    - JSON
     - wwwSitemap
   page:
     - HTML


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/178

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/176, a custom `outputFormat` was defined for the `ocw-www` sitemap, and it was assigned to the home page.  This had the side effect of causing the home template to only generate XML for the sitemap, and it stopped generating HTML for the home page.  This PR adds back the default output formats explicitly, because apparently that's required.

#### How should this be manually tested?
 - Clone `ocw-hugo-themes` and configure it to point to a locally cloned copy of this repo using `WWW_HUGO_CONFIG_PATH`
 - Clone `ocw-www` from the `mitocwcontent` org at github.mit.edu and point to that with `WWW_CONTENT_PATH`. Then spin up `ocw-www` with `npm run start:www`
 - Verify that you can visit the home page at http://localhost:3000
