### PR TITLE
store course resource description in markdown body

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -85,20 +85,12 @@ collections:
         widget: string
         help: If this is a video, this will be published as the YouTube title
       - label: Description
-        name: description
-        widget: markdown
-      - label: Body
         name: body
         widget: markdown
-        minimal: false
+        minimal: true
         link:
           - resource
           - page
-        embed:
-          - resource
-        help: >
-          The body of the resource page, displayed below
-          the page title and above the resource
       - label: Resource Type
         name: resourcetype
         required: true


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/185

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/155, we added editing of the markdown body to resources, as it was necessary for legacy courses where multiple legacy description fields are combined into the markdown body of the resource.  This PR improves upon that a bit, by configuring `ocw-studio` so that the field labeled "Description" writes its content to the markdown body, unifying where the description is stored.  The markdown editor was set to `minimal: true` and linking of pages and other resources is allowed.  This is now possible because https://github.com/mitodl/ocw-studio/pull/1364 has been merged.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally on `master`
 - Copy and paste the configuration at `course/ocw-studio.yaml` into your local `ocw-course` starter
 - Open a course with at least one resource (or create one)
 - Edit the description on that course, make sure to add in some page / resource links
 - Save and publish your course to your test org
 - View the output and make sure that the markdown in the body of your resource file looks correct
