### PR TITLE
add metadata_description and metadata_keywords fields to pages

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -26,6 +26,11 @@ collections:
         help: The plain text description of this page as seen by search engines
         required: true
 
+      - label: Metadata Keywords
+        name: metadata_keywords
+        widget: string
+        help: The search keywords for this page
+
       - label: Body
         name: body
         widget: markdown

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -23,7 +23,7 @@ collections:
       - label: Metadata Description
         name: metadata_description
         widget: string
-        help: The plain text description of this page as indexed by search engines
+        help: The plain text description of this page as seen by search engines
         required: true
 
       - label: Body

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -20,16 +20,11 @@ collections:
         widget: string
         required: true
 
-      - label: Metadata Description
-        name: metadata_description
+      - label: Description
+        name: description
         widget: string
         help: The plain text description of this page as seen by search engines
         required: true
-
-      - label: Metadata Keywords
-        name: metadata_keywords
-        widget: string
-        help: The search keywords for this page
 
       - label: Body
         name: body

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -20,6 +20,12 @@ collections:
         widget: string
         required: true
 
+      - label: Metadata Description
+        name: metadata_description
+        widget: string
+        help: The plain text description of this page as indexed by search engines
+        required: true
+
       - label: Body
         name: body
         widget: markdown

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -17,16 +17,11 @@ collections:
         widget: string
         required: true
 
-      - label: Metadata Description
-        name: metadata_description
+      - label: Description
+        name: description
         widget: string
         help: The plain text description of this page as seen by search engines
         required: true
-
-      - label: Metadata Keywords
-        name: metadata_keywords
-        widget: string
-        help: The search keywords for this page
 
       - label: Body
         name: body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -17,6 +17,12 @@ collections:
         widget: string
         required: true
 
+      - label: Metadata Description
+        name: metadata_description
+        widget: string
+        help: The plain text description of this page as indexed by search engines
+        required: true
+
       - label: Body
         name: body
         widget: markdown

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -20,7 +20,7 @@ collections:
       - label: Metadata Description
         name: metadata_description
         widget: string
-        help: The plain text description of this page as indexed by search engines
+        help: The plain text description of this page as seen by search engines
         required: true
 
       - label: Body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -23,6 +23,11 @@ collections:
         help: The plain text description of this page as seen by search engines
         required: true
 
+      - label: Metadata Keywords
+        name: metadata_keywords
+        widget: string
+        help: The search keywords for this page
+
       - label: Body
         name: body
         widget: markdown


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/725

#### What's this PR do?
This PR adds new `metadata_description` and `metadata_keywords` fields to the `page` types of content in `ocw-www` and `ocw-course`.  These values will be written into `meta` tags with the `name` "Description" and "Keywords" so they can be read by search engines for purposes of indexing.

#### How should this be manually tested?
 - Run an instance of `ocw-studio` locally
 - Copy and paste the `ocw-www/ocw-studio.yaml` and `ocw-course/ocw-studio.yaml` files into the appropriate starter in your local instance of `ocw-studio` in Django admin
 - Create a page in both types of sites, fill out the Metadata Description and Keywords fields and publish your sites to your test org
 - Verify that the description that you wrote shows up in the front matter under `metadata_description` and the keywords under `metadata_keywords`
