### PR TITLE
plain text description fields should be text and not string

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -22,7 +22,7 @@ collections:
 
       - label: Description
         name: description
-        widget: string
+        widget: text
         help: The plain text description of this page as seen by search engines
         required: true
 

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -19,7 +19,7 @@ collections:
 
       - label: Description
         name: description
-        widget: string
+        widget: text
         help: The plain text description of this page as seen by search engines
         required: true
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Follow up to https://github.com/mitodl/ocw-hugo-projects/pull/190
Closes https://github.com/mitodl/ocw-hugo-projects/issues/193

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/190, we added plain text description fields to pages in both `ocw-course` and `ocw-www`.  The widget property on these was set to `string` when it should have been `text`, as these descriptions can be long and require multi-line input.  This PR does just that, changes the widgets on them to `text`.

#### How should this be manually tested?
 - Run `ocw-studio` manually
 - Copy and paste `ocw-www/ocw-studio.yaml` and `ocw-course/ocw-studio.yaml` into their appropriate starters in your local `ocw-studio`'s Django admin interface
 - Open an existing course or create a new one and open a page or create a new one
 - Verify that the description field is now a multi line text widget
