### PR TITLE
fix: we did not add a metadata_keywords field to pages

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,7 +5,7 @@ Version 0.22.2 (Released June 09, 2022)
 --------------
 
 - plain text description fields should be text and not string (#192)
-- add metadata_description field to pages (#190)
+- add description field to pages (#190)
 
 Version 0.22.1 (Released June 02, 2022)
 --------------

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,7 +5,7 @@ Version 0.22.2 (Released June 09, 2022)
 --------------
 
 - plain text description fields should be text and not string (#192)
-- add metadata_description and metadata_keywords fields to pages (#190)
+- add metadata_description field to pages (#190)
 
 Version 0.22.1 (Released June 02, 2022)
 --------------


### PR DESCRIPTION
#### What are the relevant tickets?

no issue, I just noticed that the release notes were misleading

#### What's this PR do?

Corrects the release notes to remove "add ... metadata_keywords fields to pages"

#### How should this be manually tested?

I hope this doesn't mess up Doof too much.

