### PR TITLE
feat: learning_resource_type taxonomy added

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -41,3 +41,5 @@ security:
 markup:
   highlight:
     style: colorful
+taxonomies:
+  learning_resource_type: learning_resource_types


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
- No ticket :)

#### What's this PR do?
- Adds `learning_resource_type` [taxonomy](https://gohugo.io/content-management/taxonomies/).

#### How should this be manually tested?
- Checkout this branch
- Make sure `COURSE_HUGO_CONFIG_PATH` is set in `ocw-hugo-themes` env.
- For `ocw-hugo-themes`, checkout to the branch of this PR https://github.com/mitodl/ocw-hugo-themes/pull/753.
- Build any course locally which has learning resource types.
- Go to `http://localhost:3000/resources/` and verify that all the resources are being rendered properly
- Verify that when you click `See All`, all resources for a particular type are rendered properly.

#### Any background context you want to provide?
- Please read [this thread](https://github.com/mitodl/hq/discussions/92#discussioncomment-2954821) for context/details.

