### PR TITLE
change order of theme inheritance

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -4,7 +4,7 @@ enableRobotsTXT: true
 languageCode: en-us
 relativeURLs: false
 title: MIT OpenCourseWare
-theme: ["base-theme", "course"]
+theme: ["course", "base-theme"]
 ignoreErrors: ["error-remote-getjson"]
 outputFormats:
   coursedata:

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -24,7 +24,7 @@ outputFormats:
     baseName: sitemap-www
     isPlainText: true
     mediaType: "application/xml"
-theme: ["base-theme", "www"]
+theme: ["www", "base-theme"]
 security:
   funcs:
     getenv:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/201

#### What's this PR do?
According to https://gohugo.io/hugo-modules/theme-components, Hugo's lookup order goes through the themes defined in your project from left to right and the file with the same name found in the "leftmost" theme wins.  In our Hugo configs, our `theme` section has `base-theme` first in both `ocw-www` and `ocw-course`.  In order to be able to override layouts in the base theme, we need `base-theme` to be last.

#### How should this be manually tested?
 - Check out `ocw-hugo-projects` and `ocw-hugo-themes` on the `main` branches as well as any course from `mitocwcontent`
 - In the `.env` of your `ocw-hugo-themes` repo, make sure you have: 
```
COURSE_HUGO_CONFIG_PATH=/home/gumaerc/Code/ocw-hugo-projects/ocw-course/config.yaml
COURSE_CONTENT_PATH=/path/to/mitocwcontent/
OCW_TEST_COURSE=<your test course>
```
- In `base-theme/layouts/partials/header.html`, in the `desktop-header` div, add the following after the "contact us" link:
```
      <a href="/contact">
        <div class="text-white font-weight-bold w-100 px-3 py-2">
          contact us
        </div>
      </a>
      <div class="text-white font-weight-bold w-100 px-3 py-2">
        override not working
      </div>
```
- Copy the `header.html` partial into `course/layouts/partials` and edit the message in the div to say "override working"
- Spin up your course with `npm run start:course`
- Visit http://localhost:3000 and you should see the "override not working" message in the header
- Switch your branch in `ocw-hugo-projects` to `cg/theme-inheritance-order`
- Go back to http://localhost:3000 and the message should have changed to "override working"
