### PR TITLE
permalink added for learning_resource_types

### DIFF
--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -43,3 +43,5 @@ markup:
     style: colorful
 taxonomies:
   learning_resource_type: learning_resource_types
+permalinks:
+  learning_resource_types: "/resources/:slug/"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket :) 

#### What's this PR do?
- Defines permalink for `learning_resource_types` taxonomy so `/resources` is used instead of `/learning_resource_types`

#### How should this be manually tested?
- Checkout the branch of this PR: https://github.com/mitodl/ocw-hugo-themes/pull/753
- Build any course which has more than 10 resources for any particular type
- Go to `/resources`
- Click `See All`
- Verify that you're redirected to `/resources/type` instead of `/learning_resource_types/type`

#### Related PR
https://github.com/mitodl/ocw-hugo-themes/pull/753