### PR TITLE
Added resource list to to course config which was reverted in PR #206

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -34,6 +34,7 @@ collections:
           - resource
           - page
           - video_gallery
+          - resource-list
         embed:
           - resource
 

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -38,6 +38,35 @@ collections:
           - resource
 
   - category: Content
+    folder: content/lists
+    label: "Resource lists"
+    name: "resource-list"
+    fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Description
+        name: description
+        widget: markdown
+
+      - name: resources
+        label: Resources
+        widget: relation
+        multiple: true
+        collection: resource
+        display_field: title
+        cross_site: false
+        sortable: true
+
+  - category: Content
     folder: content/video_galleries
     label: "Video Gallery"
     name: video_gallery


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #196 

#### What's this PR do?
- Adds resource bundle to config
- Does not add resource bundle to link

#### How should this be manually tested?
- Use this config on ocw-studio
- Verify you are able to create resource bundles

#### Additional Context 
Resource list was added in PR #196 in course config. However it was not added in TABS in ocw-studio which caused problems in rendering pages thus it was reverted in PR #206. Following PR https://github.com/mitodl/ocw-studio/pull/1411 for ocw-studio adds checks to prevent this issue.
This PR adds resource list back to ocw-studio config