### PR TITLE
Pt/resource picker tabs

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -31,12 +31,63 @@ collections:
         widget: markdown
         minimal: false
         link:
-          - resource
-          - page
-          - video_gallery
-          - resource-list
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
+            embeddable: true
+          - title: "Document"
+            id: "documents"
+            contentType: "resource"
+            resourcetype: "Document"
+            embeddable: false
+            singleColumn: true
+          - title: "Other"
+            id: "other"
+            contentType: "resource"
+            resourcetype: "Other"
+            embeddable: false
+            singleColumn: true
+          - title: "Pages"
+            id: "pages"
+            contentType: "page"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
+          - title: "Video Gallery"
+            id: "video_gallery"
+            contentType: "video_gallery"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
+          - title: "Resource List"
+            id: "resource-list"
+            contentType: "resource-list"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
         embed:
-          - resource
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
+            
 
   - category: Content
     folder: content/lists
@@ -89,10 +140,50 @@ collections:
         widget: markdown
         minimal: false
         link:
-          - resource
-          - page
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
+            embeddable: true
+          - title: "Document"
+            id: "documents"
+            contentType: "resource"
+            resourcetype: "Document"
+            embeddable: false
+            singleColumn: true
+          - title: "Other"
+            id: "other"
+            contentType: "resource"
+            resourcetype: "Other"
+            embeddable: false
+            singleColumn: true
+          - title: "Pages"
+            id: "pages"
+            contentType: "page"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
         embed:
-          - resource
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
 
       - label: Videos
         name: videos
@@ -128,8 +219,44 @@ collections:
         widget: markdown
         minimal: true
         link:
-          - resource
-          - page
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
+            embeddable: true
+          - title: "Document"
+            id: "documents"
+            contentType: resource
+            resourcetype: Document
+            embeddable: false
+            singleColumn: true
+          - title: "Other"
+            id: "other"
+            contentType: resource
+            resourcetype: Other
+            embeddable: false
+            singleColumn: true
+        embed:
+          - title: "Images"
+            id: "images"
+            contentType: resource
+            resourcetype: Image
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: resource
+            resourcetype: Video
+            embeddable: true
+            singleColumn: false
       - label: Resource Type
         name: resourcetype
         required: true

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -87,7 +87,6 @@ collections:
             embeddable: true
             singleColumn: false
 
-
   - category: Content
     folder: content/lists
     label: "Resource lists"

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -43,7 +43,6 @@ collections:
             resourcetype: "Video"
             embeddable: true
             singleColumn: false
-            embeddable: true
           - title: "Document"
             id: "documents"
             contentType: "resource"
@@ -87,7 +86,7 @@ collections:
             resourcetype: "Video"
             embeddable: true
             singleColumn: false
-            
+
 
   - category: Content
     folder: content/lists
@@ -152,7 +151,6 @@ collections:
             resourcetype: "Video"
             embeddable: true
             singleColumn: false
-            embeddable: true
           - title: "Document"
             id: "documents"
             contentType: "resource"
@@ -231,7 +229,6 @@ collections:
             resourcetype: "Video"
             embeddable: true
             singleColumn: false
-            embeddable: true
           - title: "Document"
             id: "documents"
             contentType: resource

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -28,13 +28,61 @@ collections:
         widget: markdown
         minimal: false
         link:
-          - course_collections
-          - resource_collections
-          - resource
-          - page
+          - title: "Course Collections"
+            id: "course-collection"
+            contentType: "course-collection"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
+          - title: "Resource Collections"
+            id: "resource_collections"
+            contentType: "resource_collections"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
+          - title: "Document"
+            id: "documents"
+            contentType: "resource"
+            resourcetype: "Document"
+            embeddable: false
+            singleColumn: true
+          - title: "Other"
+            id: "other"
+            contentType: "resource"
+            resourcetype: "Other"
+            embeddable: false
+            singleColumn: true
+          - title: "Pages"
+            id: "pages"
+            contentType: "page"
+            resourcetype: null
+            embeddable: false
+            singleColumn: true
         embed:
-          - resource
-
+          - title: "Images"
+            id: "images"
+            contentType: "resource"
+            resourcetype: "Image"
+            embeddable: true
+            singleColumn: false
+          - title: "Videos"
+            id: "videos"
+            contentType: "resource"
+            resourcetype: "Video"
+            embeddable: true
+            singleColumn: false
   - category: Content
     folder: content/resource_collections
     label: "Resource Collections"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1419 (together with https://github.com/mitodl/ocw-studio/pull/1435).

#### What's this PR do?
This updates the config `ocw-www` and `ocw-course` config files to match the format expected by https://github.com/mitodl/ocw-studio/pull/1435.

#### How should this be manually tested?
**This needs to be tested together with https://github.com/mitodl/ocw-studio/pull/1435.** Start OCW Studio locally, and then replace the Website Starters in Django admin for ocw-www and ocw-course with the updated ones from this branch. Try renaming an existing tab and adding a new tab type; check that this works properly within the ResourcePicker menu.

