### PR TITLE
Pt/interactive assessment learning resource type

### DIFF
--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -384,6 +384,7 @@ collections:
               - "Exams with Solutions"
               - "Image Gallery"
               - "Instructor Insights"
+              - "Interactive Assessments"
               - Labs
               - "Lecture Audio"
               - "Lecture Notes"

--- a/ocw-course/ocw-studio.yaml
+++ b/ocw-course/ocw-studio.yaml
@@ -163,6 +163,7 @@ collections:
           - "Exams with Solutions"
           - "Image Gallery"
           - "Instructor Insights"
+          - "Interactive Assessments"
           - Labs
           - "Lecture Audio"
           - "Lecture Notes"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/210.

#### What's this PR do?
Adds a new "Interactive Assessment" resource type to both the course metadata and the Edit Resource drawer.

#### How should this be manually tested?
In a locally-running instance of OCW Studio, replace the website starter for `ocw-course` with the `ocw-studio.yaml` file modified in this PR. Check that "Interactive Assessment" is now an option both in the course metadata and in the Edit Resource drawer under "Learning Resource Types".