### PR TITLE
SENTRY_DSN added to the list of env variables

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -28,3 +28,4 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN

--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -38,6 +38,7 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN
 markup:
   highlight:
     style: colorful

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -38,6 +38,7 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN
 markup:
   highlight:
     style: colorful

--- a/ocw-course/config-offline.yaml
+++ b/ocw-course/config-offline.yaml
@@ -38,6 +38,7 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN
 markup:
   highlight:
     style: colorful

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -38,6 +38,7 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN
 markup:
   highlight:
     style: colorful

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -37,3 +37,4 @@ security:
       - OCW_IMPORT_STARTER_SLUG
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
+      - SENTRY_DSN


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/pull/903 & https://github.com/mitodl/ocw-studio/pull/1548

#### What's this PR do?
- Adds `SENTRY_DSN` to the list of allowed env variables in all `config.yaml` and `config-offline.yaml`
