### PR TITLE
whitelist webpack_port

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -20,6 +20,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL

--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL

--- a/ocw-course/config-offline.yaml
+++ b/ocw-course/config-offline.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -29,6 +29,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID
       - RESOURCE_BASE_URL


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/919

#### What's this PR do?
Whitelists the WEBPACK_PORT environment variable.

#### How should this be manually tested?
1. Checkout this branch of ocw-hugo-projects and [cc/ci3](https://github.com/mitodl/ocw-hugo-themes/tree/cc/ci3) of ocw-hugo-themes.
2. Set ocw-hugo-themes env var `WEBPACK_PORT` to some unused port, e.g., 4567
3. run `yarn start:course`; check that the course loads webpack assets.
4. Check that http://localhost:4567/static/css/main.css loads a css file, replacing the port number with whatever you used 
5. repeat with `yarn start:www`