### PR TITLE
allow HEAD verb and download of zip files

### DIFF
--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -49,7 +49,7 @@ markup:
 mediaTypes:
   application/zip:
     suffixes:
-    - zip
+      - zip
 taxonomies:
   learning_resource_type: learning_resource_types
 permalinks:

--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -40,9 +40,16 @@ security:
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
       - SENTRY_DSN
+  http:
+    methods:
+      - (?i)GET|HEAD
 markup:
   highlight:
     style: colorful
+mediaTypes:
+  application/zip:
+    suffixes:
+    - zip
 taxonomies:
   learning_resource_type: learning_resource_types
 permalinks:

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -49,7 +49,7 @@ markup:
 mediaTypes:
   application/zip:
     suffixes:
-    - zip
+      - zip
 taxonomies:
   learning_resource_type: learning_resource_types
 permalinks:

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -40,9 +40,16 @@ security:
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
       - SENTRY_DSN
+  http:
+    methods:
+      - (?i)GET|HEAD
 markup:
   highlight:
     style: colorful
+mediaTypes:
+  application/zip:
+    suffixes:
+    - zip
 taxonomies:
   learning_resource_type: learning_resource_types
 permalinks:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/ocw-hugo-themes/issues/937

#### What's this PR do?
This PR adds two things to the `course-v2` configs:
 - Allows the `HEAD` verb in addition to `GET` in the `security.http` configuration so that `resources.GetRemote` is allowed to make `HEAD` requests
 - Adds `application/zip` as a supported `mediaType` so ZIP files can be fetched with `resources.GetRemote`

#### How should this be manually tested?
This will be tested as part of 
