### PR TITLE
whitelist webpack_host env var

### DIFF
--- a/mit-fields/config.yaml
+++ b/mit-fields/config.yaml
@@ -20,6 +20,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID

--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID

--- a/ocw-course/config-offline.yaml
+++ b/ocw-course/config-offline.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID

--- a/ocw-course/config.yaml
+++ b/ocw-course/config.yaml
@@ -30,6 +30,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID

--- a/ocw-www/config.yaml
+++ b/ocw-www/config.yaml
@@ -29,6 +29,7 @@ security:
   funcs:
     getenv:
       - ^HUGO_
+      - WEBPACK_HOST
       - WEBPACK_PORT
       - API_BEARER_TOKEN
       - GTM_ACCOUNT_ID


### PR DESCRIPTION
This PR whitelists `WEBPACK_HOST` environment variable for Hugo, which is introduced in https://github.com/mitodl/ocw-hugo-themes/pull/964. See that PR for more context.

### How should this be manually reviewed?

Follow the steps in https://github.com/mitodl/ocw-hugo-themes/pull/964.