### PR TITLE
set default baseUrl in course-v2 back to /

### DIFF
--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -1,5 +1,5 @@
 ---
-baseUrl: "http://localhost:3000/"
+baseUrl: "/"
 enableRobotsTXT: true
 languageCode: en-us
 relativeURLs: true

--- a/ocw-course-v2/config.yaml
+++ b/ocw-course-v2/config.yaml
@@ -1,5 +1,5 @@
 ---
-baseUrl: "http://localhost:3000/"
+baseUrl: "/"
 enableRobotsTXT: true
 languageCode: en-us
 relativeURLs: false


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/972

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/227, a change was inadvertently committed that set the default `baseUrl` setting in the `ocw-course-v2` starter's Hugo config to `http://localhost:3000/`. This causes `webpack_url.html` in `ocw-hugo-themes` to become confused when rendering the Netlify deploy previews, because `site.IsServer` will evalute to false and `site.BaseURL` is not blank. This causes the theme to try and use `site_root_url.html` to build the base url, resulting in a URL like `http://:/static/js/main.175c9.js`. This PR changes that back to `/` by default.

#### How should this be manually tested?
The real test as to whether or not this fixes the deploy preview will be after it's merged and deploy previews for active PR's in `ocw-hugo-themes` are rebuilt. To do a basic test locally though:

 - Clone `ocw-hugo-themes` on the `main` branch as well as `ocw-hugo-projects` on this branch, pointing at your local `ocw-hugo-projects` with `COURSE_HUGO_CONFIG_PATH` to the `ocw-course-v2` config and pointing the content vars at a course of your choosing
 - Start up the course with `yarn start:course` and visit http://localhost:3000/
 - Inspect the source of the page and search for `localhost:3000`; you should only find one result and it should be in the appzi feedback widget
 - Switch your `ocw-hugo-projects` branch to main and reload the dev server
 - Inspect the source again and search for `localhost:3000` and you should see it being used in a bunch more places
