### PR TITLE
Added homepage settings in ocw-www studio config

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -332,3 +332,20 @@ collections:
         label: Navigation Menu
         fields:
           - { "label": "Menu", "name": "mainmenu", "widget": "menu" }
+  
+  - category: Settings
+    label: Homepage
+    name: homepage
+    files:
+      - file: data/homepage.yaml
+        name: homepage_settings
+        label: Homepage Settings
+        fields:
+          - label: Featured Promos
+            name: featured_promos
+            widget: menu
+            collection: promos
+            display_field: title
+            multiple: true
+            sortable: true
+

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -332,7 +332,7 @@ collections:
         label: Navigation Menu
         fields:
           - { "label": "Menu", "name": "mainmenu", "widget": "menu" }
-  
+
   - category: Settings
     label: Homepage
     name: homepage
@@ -343,9 +343,8 @@ collections:
         fields:
           - label: Featured Promos
             name: featured_promos
-            widget: menu
+            widget: relation
             collection: promos
             display_field: title
             multiple: true
             sortable: true
-


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #241 

#### What's this PR do?
- Adds a new setting category which can be used to sort promos.

#### How should this be manually tested?
- Use this config to generate a ocw-www site in ocw-studio
- Add promos
- Verify a new setting call `HomePage` is shown
- Open HomePage setting and sort promos
- Publish course locally
- Verify a homepage.yml is produced

#### Any background context you want to provide?

As per the latest [comment](https://github.com/mitodl/ocw-hugo-projects/issues/183#issuecomment-1382371103) by @ChristopherChudzicki , The feature to sort promos should be moved into  **Setting category** of ocw-studio. To handle this change a new setting called `HomePage` has been added in ocw-www stuidio config

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2023-01-25 at 5 39 00 PM" src="https://user-images.githubusercontent.com/87968618/214569247-42256f30-cd21-4517-ad80-a16120b55fc6.png">

