### PR TITLE
ocw-www offline config

### DIFF
--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -4,7 +4,7 @@ enableRobotsTXT: true
 languageCode: en-us
 relativeURLs: true
 title: MIT OpenCourseWare
-theme: ["course-offline", "course-v2", "base-theme"]
+theme: ["base-offline", "course-offline", "course-v2", "base-theme"]
 ignoreErrors: ["error-remote-getjson"]
 outputFormats:
   coursedata:

--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -17,7 +17,12 @@ outputs:
 theme: ["base-offline", "www-offline", "base-theme"]
 uglyurls: true
 disableKinds:
-  - instructors
+  - section
+  - taxonomy
+  - taxonomyTerm
+  - RSS
+  - sitemap
+  - 404
 security:
   funcs:
     getenv:

--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -16,6 +16,7 @@ outputs:
     - HTML
 theme: ["base-offline", "www-offline", "base-theme"]
 uglyurls: true
+paginate: 20
 disableKinds:
   - section
   - taxonomy

--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -14,16 +14,6 @@ mediaTypes:
 outputs:
   home:
     - HTML
-    - JSON
-    - wwwSitemap
-  page:
-    - HTML
-    - JSON
-outputFormats:
-  wwwSitemap:
-    baseName: sitemap-www
-    isPlainText: true
-    mediaType: "application/xml"
 theme: ["base-offline", "www-offline", "base-theme"]
 uglyurls: true
 disableKinds:

--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -1,0 +1,46 @@
+---
+baseUrl: "/"
+enableRobotsTXT: true
+languageCode: en-us
+relativeURLs: true
+title: MIT OpenCourseWare
+caches:
+  getjson:
+    maxAge: 5m
+mediaTypes:
+  application/json:
+    suffixes:
+      - json
+outputs:
+  home:
+    - HTML
+    - JSON
+    - wwwSitemap
+  page:
+    - HTML
+    - JSON
+outputFormats:
+  wwwSitemap:
+    baseName: sitemap-www
+    isPlainText: true
+    mediaType: "application/xml"
+theme: ["base-offline", "www-offline", "base-theme"]
+uglyurls: true
+disableKinds:
+  - instructors
+security:
+  funcs:
+    getenv:
+      - ^HUGO_
+      - WEBPACK_HOST
+      - WEBPACK_PORT
+      - API_BEARER_TOKEN
+      - GTM_ACCOUNT_ID
+      - RESOURCE_BASE_URL
+      - STATIC_API_BASE_URL
+      - OCW_STUDIO_BASE_URL
+      - OCW_IMPORT_STARTER_SLUG
+      - OCW_COURSE_STARTER_SLUG
+      - COURSE_BASE_URL
+      - SITEMAP_DOMAIN
+      - SENTRY_DSN


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/1111

#### What's this PR do?
This PR adds a `config-offline.yaml` for the `ocw-www` project, to be used with the `www-offline` theme in `ocw-hugo-themes`. This config disables all output formats aside from HTML for the home page, sets `relativeURLs` and `uglyurls` to true and uses `disableKinds` to prevent the rendering of any content not relevant to this config's use case: using the `www-offline` theme to render a root level index of offline sites for use with OCW mirror drives. You may also notice that both this config and the `config-offline` in `ocw-course-v2` now first import `base-offline`, a theme added in https://github.com/mitodl/ocw-hugo-themes/pull/1113 that consolidates some of the common partials used between the offline Hugo sites into one place.

#### How should this be manually tested?
This will be tested as part of https://github.com/mitodl/ocw-hugo-themes/pull/1113
