### PR TITLE
add archive_url as a hidden field in video_files

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -263,6 +263,9 @@ collections:
           - label: Video Transcript (PDF) URL
             name: video_transcript_file
             widget: string
+          - label: Archive URL
+            name: archive_url
+            widget: hidden
 
   - category: Settings
     name: metadata


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/980

#### What's this PR do?
This PR adds `archive_url` as a field under `video_files` with `widget: hidden`. The `archive_url` field only exists on legacy courses imported through [`ocw-to-hugo`](https://github.com/mitodl/ocw-to-hugo), and stores a URL to a video stored on archive.org. When `ocw-studio` uses the `ocw-course-v2` starter config as it is currently without this field defined, it will remove data in this field because it is not defined in the config. Defining the field as `hidden` prevents the field from showing up in the UI, but also prevents it from being clobbered by saving video objects.

#### How should this be manually tested?
 - Spin up [`ocw-studio`](https://github.com/mitodl/ocw-studio) locally. You will need a recent database restore and be set up for publishing courses locally.
 - Visit Django admin at http://localhost:8043/admin and log in
 - Find the `ocw-course` `WebsiteStarter` object and paste the contents of `ocw-course-v2/ocw-studio.yaml` from this branch of `ocw-hugo-projects` into the `config` field and save the object
 - Browse to http://localhost:8043/sites/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/type/resource/edit/d9613dfa-7e05-6d7e-cdd5-711882c70819/?q=part+1 and make an edit to the title (I just added "Test" at the end) and save the object, then publish the course live
 - Browse to your test org in Github and look at the latest commit for 15.S21. You should see that `archive_url` is not removed in the commit, as in the screenshot below

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/236502053-08a2e338-999e-4ef2-9227-a4be7144105c.png)
