### PR TITLE
Adding NOINDEX variable to offline configs

### DIFF
--- a/ocw-course-v2/config-offline.yaml
+++ b/ocw-course-v2/config-offline.yaml
@@ -42,6 +42,7 @@ security:
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
       - SENTRY_DSN
+      - NOINDEX
   http:
     methods:
       - (?i)GET|HEAD

--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -40,3 +40,4 @@ security:
       - COURSE_BASE_URL
       - SITEMAP_DOMAIN
       - SENTRY_DSN
+      - NOINDEX


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ocw-hugo-projects/pull/250.

#### What's this PR do?
Adds the `NOINDEX` variable to both `ocw-www` and `ocw-course-v2` offline configuration files, allowing for the variable to be whitelisted for Hugo builds. Without this update, offline builds were failing.

#### How should this be manually tested?
On the `main` branch of `ocw-hugo-themes`, run `yarn build /path/to/site/ /path/to/ocw-hugo-projects/ocw-course-v2/config-offline.yaml` (using *absolute* paths), and verify that the build completes as expected.