### PR TITLE
feat: add file_size field

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -145,6 +145,12 @@ collections:
       - label: Mime Type
         name: file_type
         widget: hidden
+      - label: Size
+        name: file_size
+        widget: hidden
+        required: false
+        default: null
+        help: The size of the file resource in bytes
       - label: File
         name: file
         widget: file

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -266,6 +266,12 @@ collections:
           - Video
           - Document
           - Other
+      - label: Size
+        name: file_size
+        widget: hidden
+        required: false
+        default: null
+        help: The size of the file resource in bytes
       - label: File
         name: file
         widget: file


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1680

#### What's this PR do?

Adds a file_size field to the resource collection config.

I've kept `widget: hidden` because we don't have a requirement for displaying the field on studio yet.

#### How should this be manually tested?

This field is not used anywhere at this time. We just need to ensure existing functionality does not break.

1. Navigate to your local clone of `ocw-hugo-projects`. And checkout `hussaintaj/1680-file-size` branch.
2. Navigate to your local setup of `ocw-studio` and checkout `master`.
3. In your studio's env file set `OCW_HUGO_PROJECTS_BRANCH="hussaintaj/1680-file-size"`
4. Start/Restart OCW Studio.
5. Run
    ```
    docker-compose exec web ./manage.py override_site_config -s ocw-course-v2 -c path/to/ocw-hugo-projects/ocw-course-v2/ocw-studio.yaml
    docker-compose exec web ./manage.py override_site_config -s ocw-www -c path/to/ocw-hugo-projects/ocw-www/ocw-studio.yaml
    ```
6. Open a course or www site.
    **Expected Behavior**: The UI is working. Specifically the resource-related UI elements.
7. Add or update a resource.
8. Run
    ```
    docker-compose exec web ./manage.py backpopulate_pipelines --filter <id>
    ```
9. Publish the test site.
10. **Expected Behavior**: The backend (GitHub) content file for your resource has a `file_size` field
11. **Expected Behavior**: Publishing succeeds.