### PR TITLE
re-enable the section kind in www-offline

### DIFF
--- a/ocw-www/config-offline.yaml
+++ b/ocw-www/config-offline.yaml
@@ -18,7 +18,6 @@ theme: ["base-offline", "www-offline", "base-theme"]
 uglyurls: true
 paginate: 20
 disableKinds:
-  - section
   - taxonomy
   - taxonomyTerm
   - RSS


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/1174

#### What's this PR do?
This PR re-enables the `section` kind in the offline config for `ocw-www`. https://github.com/mitodl/ocw-hugo-themes/pull/1175 adds a section for search, and it will not be rendered unless this setting is changed. As part of that PR, irrelevant content to the `www-offline` theme will be hidden using front matter tags directly on the irrelevant content as overrides in `www-offline`

#### How should this be manually tested?
Tested along with https://github.com/mitodl/ocw-hugo-themes/pull/1175
