### PR TITLE
Adding hide download option to course metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -775,6 +775,11 @@ collections:
                 Education Policy: []
                 Educational Technology: []
                 Higher Education: []
+          - label: Hide Course Download
+            name: hide_download
+            required: true
+            widget: boolean
+            help: Enable this setting to hide the course download button
           - label: "Legacy UID"
             name: "legacy_uid"
             widget: "hidden"


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Part of the solution to https://github.com/mitodl/hq/issues/1751.

#### What's this PR do?
Adds a "Hide Course Download" (true/false) option to the course-level metadata. When this is enabled, Hugo will not render the course download button; that change is in `ocw-hugo-themes`.

#### How should this be manually tested?
Start OCW Studio, using `docker compose up`, and replace the `course-v2` start with the contents of `ocw-course-v2/ocw-studio.yaml`. Update the value for `Hide Course Download` in any course's metadata, test publishing that course and verify that there is now a `hide_download` field with the appropriately-set value (`true/false`) in the `course.json` file.
