### PR TITLE
Add a draft setting for course collections

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -316,6 +316,11 @@ collections:
         widget: boolean
         help: Enable this setting to prevent publishing in production
 
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
       - label: First name
         name: first_name
         widget: string


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/151.

#### What's this PR do?
Adds a draft setting to course collections; all other collections currently have this setting.

Also, changes the order of the fields for `Instructor` so that the draft setting is first (consistent with all other content).

#### How should this be manually tested?
Start OCW Studio with `docker compose up`, and navigate to `http://localhost:8043/admin/websites/websitestarter/` in Django admin. Replace the starter for `ocw-www` with the content of `ocw-www/ocw-studio.yaml` from this branch. Stop the OCW Studio containers, and restart OCW Studio. Navigate to `http://localhost:8043/sites/ocw-www`, and confirm that there is now a `draft` setting for Course Collections. Set this to true, and verify that publish warnings appear, as expected.