### PR TITLE
Add Recitation Notes as Learning Resource Type

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -193,6 +193,7 @@ collections:
           - Projects
           - "Projects with Examples"
           - Readings
+          - "Recitation Notes"
           - "Recitation Videos"
           - "Simulation Videos"
           - Simulations
@@ -417,6 +418,7 @@ collections:
               - Projects
               - "Projects with Examples"
               - Readings
+              - "Recitation Notes"
               - "Recitation Videos"
               - "Simulation Videos"
               - Simulations


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2062

#### What's this PR do?
Adds a new "Recitation Notes" learning resource type to both the course metadata and the Edit Resource drawer.

#### How should this be manually tested?
Spin up local OCW-Studio, replace the website starter for ocw-course with the ocw-studio.yaml file modified in this PR. Check that "Recitation Notes" is now an option both in the course metadata and in the Edit Resource drawer under "Learning Resource Types".

### Screenshots
<img width="618" alt="image" src="https://github.com/mitodl/ocw-hugo-projects/assets/109785089/47047287-56d1-4553-abed-ca64c4a233d2">

<img width="620" alt="image" src="https://github.com/mitodl/ocw-hugo-projects/assets/109785089/f2a4216d-3426-427c-a9d1-a0cfcb11cdc5">
