### PR TITLE
feat(config): add form widget for archive_url

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -258,7 +258,7 @@ collections:
         widget: object
         condition: { field: resourcetype, equals: Video }
         help: >
-          Internal YouTube fields, don't edit
+          Internal related resource URLs, don't edit
           unless you know what you're doing
         fields:
           - label: Video Thumbnail URL

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -270,12 +270,9 @@ collections:
           - label: Video Transcript (PDF) URL
             name: video_transcript_file
             widget: string
-          - label: Archive URL
+          - label: Internet Archive URL
             name: archive_url
             widget: string
-            help: >
-              An alternative download link,
-              often sourced from the Internet Archive.
 
   - category: Settings
     name: metadata

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -272,7 +272,10 @@ collections:
             widget: string
           - label: Archive URL
             name: archive_url
-            widget: hidden
+            widget: string
+            help: >
+              An alternative download link,
+              often sourced from the Internet Archive.
 
   - category: Settings
     name: metadata


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2759

# Description (What does it do?)

This PR updates the studio configuration which enables the user to edit the `archive_url` field in video resources.

# Screenshots (if appropriate):


<img width="1645" alt="Screenshot 2023-10-30 at 3 38 43 PM" src="https://github.com/mitodl/ocw-hugo-projects/assets/71316217/0c8289c5-a80b-40ff-a59c-d9e8e9b0162d">



# How can this be tested?

We will use Studio to test these configurations.

1. Navigate to your local `ocw-hugo-projects` directory.
2. Check out the branch `hussaintaj/2759-archive-url`.
3. Copy the contents of the file `ocw-course-v2/ocw-studio.yaml`. 
4. Navigate to your local `ocw-studio` directory.
5. Paste the contents you copied into `localdev/configs/default-course-config.yml`.
6. Start Studio i.e. `docker-compose up`.
7. Run
    ```sh
    docker-compose exec web ./manage.py override_site_config -s ocw-course-v2 -c localdev/configs/default-course-config.yml
    ```
8. Open a course with video resources.
9. Open a video resource.
10. Expect the edit form of any video resource to have a field for `archive_url`.
11. Update the URL and save the resource.
12. Publish the course.
13. Expect the publish action to be completed successfully.

> Note: By default, we store videos for the video resources we create. The download links reference our internal video files. `archive_url` is only rendered if we don't have the video files in our storage. If you'd like to test and see the changed URL rendered onto the page, the easiest way would be to copy a legacy course. For example, [this resource](https://ocw.mit.edu/courses/3-091-introduction-to-solid-state-chemistry-fall-2018/resources/closing-remarks-by-prof/).

