### PR TITLE
Add Russian language topic to metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -629,6 +629,7 @@ collections:
                   - Italian
                   - Japanese
                   - German
+                  - Russian
                 Linguistics:
                   - Phonology
                   - Syntax


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3182.

# Description (What does it do?)
This PR adds a new Russian language option to course metadata.


# How can this be tested?
Start OCW Studio locally. Paste the contents of `ocw-course-v2/ocw-studio.yaml` from this branch into the appropriate Website Starter in Django admin. Then, navigate to `http://localhost:8043/sites`, select any course site, and click on `Metadata` under `Settings`.  Verify that is now possible to add `Humanities`->`Language`->`Russian` under `Topics`.
