### PR TITLE
Fix Level Non-Credit in Course Metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -365,7 +365,7 @@ collections:
             options:
               - "Undergraduate"
               - "Graduate"
-              - "Non Credit"
+              - "Non-Credit"
               - "High School"
             widget: "select"
           - label: "Term"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3175

### Description (What does it do?)
Changes "Non Credit" to "Non-Credit" in the course metadata.


### How can this be tested?
1. Checkout to this branch
2. Start OCW Studio locally. 
3. Copy the contents of `ocw-course-v2/ocw-studio.yaml` from this branch into the `ocw-course-v2` Website Starter config in Django admin. 
4. Then, navigate to http://localhost:8043/sites, select any course site, and click on Metadata under Settings. Verify that you see `Non-Credit` instead of `Non Credit`.
