### PR TITLE
fix: license labels

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -216,7 +216,7 @@ collections:
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
           - label: All Rights Reserved
-            value: https://en.wikipedia.org/wiki/All_rights_reserved/
+            value: https://en.wikipedia.org/wiki/All_rights_reserved
         widget: select
         default: https://creativecommons.org/licenses/by-nc-sa/4.0/
         required: true

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -215,8 +215,6 @@ collections:
             value: https://creativecommons.org/licenses/by-nc/4.0/
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
-          - label: All Rights Reserved
-            value: https://en.wikipedia.org/wiki/All_rights_reserved
         widget: select
         default: https://creativecommons.org/licenses/by-nc-sa/4.0/
         required: true

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -207,11 +207,11 @@ collections:
       - label: License
         name: license
         options:
-          - label: CC-BY-NC-SA
+          - label: CC BY-NC-SA
             value: https://creativecommons.org/licenses/by-nc-sa/4.0/
-          - label: CC-BY
+          - label: CC BY
             value: https://creativecommons.org/licenses/by/4.0/
-          - label: CC-BY-NC
+          - label: CC BY-NC
             value: https://creativecommons.org/licenses/by-nc/4.0/
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -216,7 +216,7 @@ collections:
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
           - label: All Rights Reserved
-            value: https://ocw.mit.edu/pages/privacy-and-terms-of-use/
+            value: https://en.wikipedia.org/wiki/All_rights_reserved/
         widget: select
         default: https://creativecommons.org/licenses/by-nc-sa/4.0/
         required: true

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -215,6 +215,8 @@ collections:
             value: https://creativecommons.org/licenses/by-nc/4.0/
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
+          - label: All Rights Reserved
+            value: https://ocw.mit.edu/pages/privacy-and-terms-of-use/
         widget: select
         default: https://creativecommons.org/licenses/by-nc-sa/4.0/
         required: true


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

This PR fixes the labels of existing licenses. This does not impact existing data. Only the Studio UI is affected.

### Screenshots (if appropriate):

<img width="1423" alt="Screenshot 2024-02-01 at 4 50 13 PM" src="https://github.com/mitodl/ocw-hugo-projects/assets/71316217/0e5a9d59-3dbb-4878-b490-6dae4a20fe4d">



### How can this be tested?

1. Navigate to your local `ocw-studio` projects.
2. Add the following in your `.env` file.
    ```
    GITHUB_WEBHOOK_BRANCH=hussaintaj/license-all-rights-reserved
   ```
3. Start/Restart Studio.
4. Run the following command in the shell.
    ```
    docker-compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects
    ```
5. Open any resource in the Studio UI.
6. Observe the license field.
7. Expect there to be no `-` between `CC` and the license name.


### Additional Context

Originated from https://github.com/mitodl/ocw-hugo-projects/pull/271#discussion_r1461855581


