### PR TITLE
Add Quechua language topic to metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -630,6 +630,7 @@ collections:
                   - Japanese
                   - German
                   - Russian
+                  - Quechua
                 Linguistics:
                   - Phonology
                   - Syntax


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3485.

### Description (What does it do?)
This PR adds a new Quechua language option to course metadata.

### How can this be tested?
Start OCW Studio locally. Paste the contents of `ocw-course-v2/ocw-studio.yaml` from this branch into the appropriate Website Starter in Django admin. Then, navigate to `http://localhost:8043/sites`, select any course site, and click on `Metadata` under `Settings`.  Verify that is now possible to add `Humanities`->`Language`->`Quechua` under `Topics`.

Once https://github.com/mitodl/ocw-studio/pull/2083 is merged, this can also be tested by setting `GITHUB_WEBHOOK_BRANCH=pt/quechua_language_option` in the OCW Studio `.env` file, restarting the Studio containers, and then running `docker compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects` instead of pasting the starter manually.