### PR TITLE
refactor(config): remove unused `title` field from external-resource

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -280,11 +280,6 @@ collections:
     label: External Resources
     folder: content/external-resources
     fields:
-      - label: Title
-        name: title
-        widget: string
-        required: true
-
       - label: URL
         name: external_url
         widget: string


### PR DESCRIPTION
### What are the relevant tickets?
Relates to https://github.com/mitodl/hq/issues/3358

Required for https://github.com/mitodl/ocw-studio/pull/2130


### Description (What does it do?)

Studio uses `WebsiteContent.title` instead of `WebsiteContent.metadata.title`. This PR removes the title field from the metadata because it remains unused and might cause confusion for future development.

### How can this be tested?

1. Checkout branch `hussaintaj/remove-redundant-field` in your local clone of `ocw-hugo-projects`.
2. Navigate to your local `ocw-studio` project.
3. Replace the contents of `ocw-studio/localdev/configs/default-course-config.yml` with the content of `ocw-hugo-projects/ocw-course-v2/ocw-studio.yaml`.
3. Run
    ```sh
    docker compose exec web ./manage.py override_site_config -c localdev/configs/default-course-config.yml -s ocw-course-v2
    ```
6. Open [Studio](http://localhost:8043).
7. Open a course.
8. Expect to see an `External Resources` link in the left nav.
9. Open the `External Resources` tab.
10. Add a new external resource.
11. Expect the previous step to succeed.
12. Open/Create a page.
13. Add a link to the external resource via the `Add Link` button in the CKEditor UI.
14. Expect the previous step to succeed.
15. Select `Menu` from the left navigation.
16. Add a reference to the external resource you created in the menu.
17. Expect the previous step to succeed.


