### PR TITLE
Add SP department option

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -410,6 +410,7 @@ collections:
               - MAS
               - PE
               - RES
+              - SP
               - STS
               - WGS
             widget: "select"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/3793

### Description (What does it do?)
This PR adds a new `SP` (Special Programs) option to OCW Studio departments.

### How can this be tested?
Start OCW Studio locally with `docker compose up`. Set `GITHUB_WEBHOOK_BRANCH=pt/add_sp_department` in the OCW Studio `.env` file, restart the Studio containers, and then run `docker compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects`. Verify that `SP` is now available as a department option in any course's metadata.