### PR TITLE
config(course): add title update license fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: VERSION|RELEASE.rst
       - id: check-merge-conflict
       - id: check-yaml
       - id: check-added-large-files

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -214,6 +214,8 @@ collections:
             value: https://creativecommons.org/licenses/by/4.0/
           - label: CC BY-NC
             value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: CC BY-SA
+            value: https://creativecommons.org/licenses/by-sa/4.0/
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
         widget: select
@@ -280,6 +282,12 @@ collections:
     label: External Resources
     folder: content/external-resources
     fields:
+      - label: Title
+        name: title
+        widget: string
+        required: true
+        help: The default link text for this external resource.
+
       - label: URL
         name: external_url
         widget: string
@@ -298,11 +306,13 @@ collections:
             value: https://creativecommons.org/licenses/by/4.0/
           - label: CC BY-NC
             value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: CC BY-SA
+            value: https://creativecommons.org/licenses/by-sa/4.0/
           - label: public domain
             value: https://creativecommons.org/publicdomain/zero/1.0/
           - label: All Rights Reserved
             value: https://en.wikipedia.org/wiki/All_rights_reserved
-        default: https://creativecommons.org/licenses/by-nc-sa/4.0/
+        default: https://en.wikipedia.org/wiki/All_rights_reserved
         required: true
 
       - label: Include non-OCW licensing warning

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -208,12 +208,12 @@ collections:
       - label: License
         name: license
         options:
-          - label: CC BY-NC-SA
-            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
           - label: CC BY
             value: https://creativecommons.org/licenses/by/4.0/
           - label: CC BY-NC
             value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: CC BY-NC-SA
+            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
           - label: CC BY-SA
             value: https://creativecommons.org/licenses/by-sa/4.0/
           - label: public domain
@@ -300,12 +300,12 @@ collections:
         name: license
         widget: select
         options:
-          - label: CC BY-NC-SA
-            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
           - label: CC BY
             value: https://creativecommons.org/licenses/by/4.0/
           - label: CC BY-NC
             value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: CC BY-NC-SA
+            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
           - label: CC BY-SA
             value: https://creativecommons.org/licenses/by-sa/4.0/
           - label: public domain


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4065

### Description (What does it do?)

This PR adds a help text to the title. The title is a required field and is not required to be defined, but it has to be defined to add the help text.

This PR also adds a new license option `BY CC-SA` and changes default for external resources as requested in https://github.com/mitodl/hq/issues/4065.

### Screenshots (if appropriate):

<img width="544" alt="Screenshot 2024-04-24 at 3 29 48 PM" src="https://github.com/mitodl/ocw-hugo-projects/assets/71316217/27ede97a-2965-41a1-8bad-a36dc5ae772c">


### How can this be tested?

1. Checkout branch `hussaintaj/external-resource-title-help-text` in your local clone of `ocw-hugo-projects`.
2. Navigate to your local `ocw-studio` project.
3. Replace the contents of `ocw-studio/localdev/configs/default-course-config.yml` with the content of `ocw-hugo-projects/ocw-course-v2/ocw-studio.yaml`.
4. Run
    ```sh
    docker compose exec web ./manage.py override_site_config -c localdev/configs/default-course-config.yml -s ocw-course-v2
    ```
5. Open [Studio](http://localhost:8043).
6. Open a course.
7. Open the `External Resources` tab.
8. Add a new external resource.
9. Expect to see the help text for the title field.
10. Expect to see a new license option `BY CC-SA`.
11. Except the default value to be `All Rights Reserved`.
12. Fill in the form and save the external resource.
13. Open/Create a page.
14. Add a link to the external resource via the `Add Link` button in the CKEditor UI.
15. Save the page.
16. Expect the previous step to succeed.

