### PR TITLE
Link and embed resources

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -96,7 +96,6 @@ collections:
           - resource_collections
           - resource
           - page
-          - external-resource
         embed:
           - resource
 
@@ -137,7 +136,6 @@ collections:
           - resource_collections
           - resource
           - page
-          - external-resource
 
         embed:
           - resource

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -82,7 +82,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this course list as seen by search engines
+        help: The plain text description of the list as seen by search engines
 
       - label: Body
         name: body
@@ -122,7 +122,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this course collection as seen by search engines
+        help: The plain text description of collection as seen by search engines
 
       - label: Body
         name: body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -81,7 +81,24 @@ collections:
 
       - label: Description
         name: description
+        widget: text
+        help: The plain text description of this page as seen by search engines
+
+      - label: Body
+        name: body
         widget: markdown
+        minimal: false
+        allowed_html:
+          - sub
+          - sup
+        link:
+          - course_collections
+          - resource_collections
+          - resource
+          - page
+          - external-resource
+        embed:
+          - resource
 
       - label: Courses
         name: courses
@@ -103,10 +120,28 @@ collections:
         widget: string
         required: true
 
-      - label: "Description"
-        name: "description"
-        widget: "markdown"
+      - label: Description
+        name: description
+        widget: text
+        help: The plain text description of this page as seen by search engines
 
+      - label: Body
+        name: body
+        widget: markdown
+        minimal: false
+        allowed_html:
+          - sub
+          - sup
+        link:
+          - course_collections
+          - resource_collections
+          - resource
+          - page
+          - external-resource
+
+        embed:
+          - resource
+        
       - label: Cover Image
         name: cover-image
         widget: relation

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -122,7 +122,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of collection as seen by search engines
+        help: The plain text description of the collection as seen by search engines
 
       - label: Body
         name: body
@@ -136,7 +136,6 @@ collections:
           - resource_collections
           - resource
           - page
-
         embed:
           - resource
 

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -82,7 +82,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this page as seen by search engines
+        help: The plain text description of this course-list as seen by search engines
 
       - label: Body
         name: body
@@ -122,7 +122,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this page as seen by search engines
+        help: The plain text description of this course-collection as seen by search engines
 
       - label: Body
         name: body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -122,7 +122,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of the collection as seen by search engines
+        help: The plain text description of collection as seen by search engines
 
       - label: Body
         name: body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -82,7 +82,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this course-list as seen by search engines
+        help: The plain text description of this course list as seen by search engines
 
       - label: Body
         name: body
@@ -122,7 +122,7 @@ collections:
       - label: Description
         name: description
         widget: text
-        help: The plain text description of this course-collection as seen by search engines
+        help: The plain text description of this course collection as seen by search engines
 
       - label: Body
         name: body


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3855
Relevant PR: https://github.com/mitodl/ocw-hugo-themes/pull/1397

### Description (What does it do?)
Adds functionality to link and embed resources in `ocw-www `course lists and course collections.

### How can this be tested?
One of the ways to test this would be:
1. Checkout to this branch
2. Use `OCW_HUGO_THEMES_BRANCH=ibrahim/3855/render-body-in-course-collection` in ocw-studio .env
3. Spin up `ocw-studio`
4. Update pipelines:
i. `docker-compose exec web ./manage.py upsert_theme_assets_pipeline`
ii. `docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www`
5. Open concourse interface: http://concourse:8080/
Unpause `ocw-themes-assets` pipeline and trigger a build for it. Wait for it to complete.
6. Copy the contents of ocw-www/ocw-studio.yaml from this branch into the `ocw-www` Website Starter config in Django admin.
7. In course lists and course collections, you will now be able to `link` and `embed stuff`. 
8. After you publish, you should be able to see the changes at `localhost:8045` and `localhost:8044`. Go to a respective course collection, make sure course collection and course lists render fine.
9. Test this PR along with https://github.com/mitodl/ocw-hugo-themes/pull/1397.


