### PR TITLE
Remove: course_image_thumbnail field

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -370,16 +370,6 @@ collections:
               field: "resourcetype"
               filter_type: "equals"
               value: "Image"
-          - label: Course Image Thumbnail
-            name: course_image_thumbnail
-            widget: relation
-            collection: resource
-            display_field: title
-            multiple: false
-            filter:
-              field: "resourcetype"
-              filter_type: "equals"
-              value: "Image"
           - label: "Department Numbers"
             min: 1
             multiple: true


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3132

### Related PRs
https://github.com/mitodl/ocw-hugo-themes/pull/1423
https://github.com/mitodl/ocw-studio/pull/2232

### Description (What does it do?)
Removes `course_image_thumbnail` field from `ocw-studio` course config.

### How can this be tested?
1. Checkout to this branch
2. Copy all the code from `ocw-course-v2/ocw-studio.yaml`
3. Start `ocw-studio` locally.
4. Paste the code into `WebsiteStarter` `ocw-course-v2` config from Django Admin.
5. Go to `localhost:8043/sites` and Create a new course site or open any existing one. Go to metadata from left navbar. You should no longer see Course Image Thumbnail field.
