### PR TITLE
Remove min: 1 value for department numbers

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -371,7 +371,6 @@ collections:
               filter_type: "equals"
               value: "Image"
           - label: "Department Numbers"
-            min: 1
             multiple: true
             name: "department_numbers"
             options:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4850

### Description (What does it do?)
Removes `min: 1` value for department numbers from course metadata.

### How can this be tested?
1. Copy code from `ocw-course-v2/ocw-studio.yaml` of this branch.
2. Spin up `ocw-studio`.
3. Go to `django-admin`, WebsiteStarters, and paste the code into config for `ocw-course-v2`.
4. Create a new course site locally or go to an existing one. Click on metadata from left menu. Have empty `Department Numbers` option and save it. It will work. (Otherwise it doesn't without this PR's changes - you can check locally or RC)
