### PR TITLE
Remove RES from Available Departments in OCW config

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -409,7 +409,6 @@ collections:
               - IDS
               - MAS
               - PE
-              - RES
               - SP
               - STS
               - WGS


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4854

### Description (What does it do?)
Remove RES from Available Departments in OCW course-v2 config for course metadata.

### How can this be tested?
1. Copy code from `ocw-course-v2/ocw-studio.yaml` of this branch.
2. Spin up `ocw-studio`.
3. Go to `django-admin`, `WebsiteStarters`, and paste the code into config for `ocw-course-v2`.
4. Create a new course site locally. Click on metadata from left menu. You will no longer see an option for "RES" under "Department Numbers".
