### PR TITLE
Add Status and Wayback Tracking Fields to External Resources

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -324,19 +324,29 @@ collections:
           If true, user sees warning that external content is not
           covered by OCW licensing.
 
-      - label: Is Broken
-        name: is_broken
+      - label: Status
+        name: status
         widget: hidden
-        default: null
         required: false
-        help: Whether or not this link is broken.
+        help: The current status of the external resource (e.g., valid, broken, unchecked, check_failed).
 
-      - label: Internet Archive Backup URL
-        name: backup_url
+      - label: Wayback URL
+        name: wayback_url
         widget: hidden
-        default: null
         required: false
-        help: URL to use when is_broken is true.
+        help: URL to the last Wayback Machine snapshot of the resource.
+
+      - label: Wayback Status
+        name: wayback_status
+        widget: hidden
+        required: false
+        help: The status of the Wayback Machine snapshot (pending, success, error).
+
+      - label: Wayback Status Extended
+        name: wayback_status_ext
+        widget: hidden
+        required: false
+        help: Extended information on Wayback Machine status if available.
 
   - category: Settings
     name: metadata

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -328,7 +328,9 @@ collections:
         name: status
         widget: hidden
         required: false
-        help: The current status of the external resource (e.g., valid, broken, unchecked, check_failed).
+        help: >
+          The current status of the external resource
+          (e.g., valid, broken, unchecked, check_failed).
 
       - label: Wayback URL
         name: wayback_url
@@ -340,7 +342,9 @@ collections:
         name: wayback_status
         widget: hidden
         required: false
-        help: The status of the Wayback Machine snapshot (pending, success, error).
+        help: >
+          The status of the Wayback Machine snapshot
+          (e.g., pending, success, error).
 
       - label: Wayback Status Extended
         name: wayback_status_ext

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -338,20 +338,6 @@ collections:
         required: false
         help: URL to the last Wayback Machine snapshot of the resource.
 
-      - label: Wayback Status
-        name: wayback_status
-        widget: hidden
-        required: false
-        help: >
-          The status of the Wayback Machine snapshot
-          (e.g., pending, success, error).
-
-      - label: Wayback Status Extended
-        name: wayback_status_ext
-        widget: hidden
-        required: false
-        help: Extended information on Wayback Machine status if available.
-
   - category: Settings
     name: metadata
     label: Metadata

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -296,6 +296,13 @@ collections:
           The URL. For example,
           https://owl.english.purdue.edu/owl/resource/747/01/
 
+      - label: Wayback URL
+        name: wayback_url
+        widget: string
+        required: false
+        readOnly: true
+        help: URL to the last Wayback Machine snapshot of the resource.
+
       - label: License
         name: license
         widget: select
@@ -331,12 +338,6 @@ collections:
         help: >
           The current status of the external resource
           (e.g., valid, broken, unchecked, check_failed).
-
-      - label: Wayback URL
-        name: wayback_url
-        widget: hidden
-        required: false
-        help: URL to the last Wayback Machine snapshot of the resource.
 
   - category: Settings
     name: metadata

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -502,19 +502,29 @@ collections:
           If true, user sees warning that external content is not
           covered by OCW licensing.
 
-      - label: Is Broken
-        name: is_broken
+      - label: Status
+        name: status
         widget: hidden
-        default: null
         required: false
-        help: Whether or not this link is broken.
+        help: The current status of the external resource (e.g., valid, broken, unchecked, check_failed).
 
-      - label: Internet Archive Backup URL
-        name: backup_url
+      - label: Wayback URL
+        name: wayback_url
         widget: hidden
-        default: null
         required: false
-        help: URL to use when is_broken is true.
+        help: URL to the last Wayback Machine snapshot of the resource.
+
+      - label: Wayback Status
+        name: wayback_status
+        widget: hidden
+        required: false
+        help: The status of the Wayback Machine snapshot (pending, success, error).
+
+      - label: Wayback Status Extended
+        name: wayback_status_ext
+        widget: hidden
+        required: false
+        help: Extended information on Wayback Machine status if available.
 
   - category: Content
     folder: content/instructors

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -516,26 +516,12 @@ collections:
         required: false
         help: URL to the last Wayback Machine snapshot of the resource.
 
-      - label: Wayback Status
-        name: wayback_status
-        widget: hidden
-        required: false
-        help: >
-          The status of the Wayback Machine snapshot
-          (e.g., pending, success, error).
-
-      - label: Wayback Status Extended
-        name: wayback_status_ext
-        widget: hidden
-        required: false
-        help: Extended information on Wayback Machine status if available.
-
   - category: Content
     folder: content/instructors
     label: Instructor
     name: instructor
     slug: text_id
-    fields:
+    fields:m
       - label: Draft
         name: draft
         required: true

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -521,7 +521,7 @@ collections:
     label: Instructor
     name: instructor
     slug: text_id
-    fields:m
+    fields:
       - label: Draft
         name: draft
         required: true

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -474,6 +474,13 @@ collections:
           The URL. For example,
           https://owl.english.purdue.edu/owl/resource/747/01/
 
+      - label: Wayback URL
+        name: wayback_url
+        widget: string
+        required: false
+        readOnly: true
+        help: URL to the last Wayback Machine snapshot of the resource.
+
       - label: License
         name: license
         widget: select
@@ -509,12 +516,6 @@ collections:
         help: >
           The current status of the external resource
           (e.g., valid, broken, unchecked, check_failed).
-
-      - label: Wayback URL
-        name: wayback_url
-        widget: hidden
-        required: false
-        help: URL to the last Wayback Machine snapshot of the resource.
 
   - category: Content
     folder: content/instructors

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -506,7 +506,9 @@ collections:
         name: status
         widget: hidden
         required: false
-        help: The current status of the external resource (e.g., valid, broken, unchecked, check_failed).
+        help: >
+          The current status of the external resource
+          (e.g., valid, broken, unchecked, check_failed).
 
       - label: Wayback URL
         name: wayback_url
@@ -518,7 +520,9 @@ collections:
         name: wayback_status
         widget: hidden
         required: false
-        help: The status of the Wayback Machine snapshot (pending, success, error).
+        help: >
+          The status of the Wayback Machine snapshot
+          (e.g., pending, success, error).
 
       - label: Wayback Status Extended
         name: wayback_status_ext


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5355

### Description (What does it do?)
This pull request improves the management of external resources in OCW Studio:

* Adds `status` Field: Added the status field (`unchecked`, `valid`, `broken`, `check_failed`) to replace `is_broken`.
* Adds `wayback_url`,  to track Wayback Machine snapshots (and replace `backup_url`).

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Test with steps given in https://github.com/mitodl/ocw-studio/pull/2308

