### PR TITLE
Add 'Is Quote' Boolean Field for OCW Testimonial Quotes

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -288,8 +288,8 @@ collections:
         name: is_quote
         widget: boolean
         help: >
-          Enable this setting if the testimonial is a quote only. 
-          If enabled, the Body will not be used, 
+          Enable this setting if the testimonial is a quote only.
+          If enabled, the Body will not be used,
           and the Lead Quote will be displayed instead.
         default: false
 

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -296,7 +296,7 @@ collections:
         name: body
         widget: markdown
         minimal: false
-        help: "Note: This field is ignored if 'Is Quote' is enabled."
+        help: "Note: Body is ignored if 'Is Quote' is enabled."
 
   - category: Content
     folder: content/resources

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -288,8 +288,9 @@ collections:
         name: is_quote
         widget: boolean
         help: > 
-          Enable this setting if the testimonial is a quote only. If enabled,
-          the Body will not be used, and the Lead Quote will be displayed instead.
+          Enable this setting if the testimonial is a quote only. 
+          If enabled, the Body will not be used, 
+          and the Lead Quote will be displayed instead.
         default: false
 
       - label: Body

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -249,7 +249,7 @@ collections:
         required: true
         widget: boolean
         help: Enable this setting to prevent publishing in production
-
+      
       - label: Title
         name: title
         widget: string
@@ -284,10 +284,19 @@ collections:
         name: leadquote
         widget: string
 
+      - label: Is Quote
+        name: is_quote
+        widget: boolean
+        help: > 
+          Enable this setting if the testimonial is a quote only. If enabled,
+          the Body will not be used, and the Lead Quote will be displayed instead.
+        default: false
+
       - label: Body
         name: body
         widget: markdown
         minimal: false
+        help: "Note: This field is ignored if 'Is Quote' is enabled."
 
   - category: Content
     folder: content/resources


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/1384

### Description (What does it do?)
Adds `Is Quote` Boolean Field for OCW Testimonial Quotes and relevant helping text.

We need the `is_quote` flag for new design of OCW Stories. If it's true, then the Quotes card is displayed with a clickable Modal instead of being redirected to the Story Single page.
Eg. The card in the middle:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f4792e51-bfd8-491c-b130-db205dd4e8ec">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/31fb9dea-59b0-4768-8bca-9a2bbfbfe7dc">

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a4b30041-688c-4709-b567-84be0f62bb31)

### How can this be tested?
Add the code from this branch to your local `ocw-www` website-starter from admin panel. Create a new story from your local `ocw-studio` and make sure the story created has a boolean `is_quote` field in the frontmatter of the markdown file.

Note: `is_quote` is used by this PR: https://github.com/mitodl/ocw-hugo-themes/pull/1460 