### PR TITLE
Require YouTube ID for Add Video Resource button

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -247,6 +247,7 @@ collections:
           - label: Youtube ID
             name: youtube_id
             widget: string
+            required: true
           - label: Youtube Description
             name: youtube_description
             widget: text

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -436,6 +436,7 @@ collections:
           - label: Youtube ID
             name: youtube_id
             widget: string
+            required: true
           - label: Youtube Description
             name: youtube_description
             widget: text


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/4709

### Description (What does it do?)
Makes Youtube ID mandatory for video resources created via new Add Video Resource button.

### How can this be tested?
Testing will be done in this PR instead: https://github.com/mitodl/ocw-studio/pull/2370
