### PR TITLE
Remove Name field in Studio for OCW Stories

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -255,10 +255,6 @@ collections:
         widget: string
         required: true
 
-      - label: Name
-        name: name
-        widget: string
-
       - label: Location
         name: location
         widget: string


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6320

### Description (What does it do?)
Removes name field in Studio for OCW Stories.


### How can this be tested?
Create a new story with the updated config from this branch and make sure the `Name` field does not appear. Steps for this are:
1. Copy the `ocw-www` config code from this branch.
2. Spin up OCW-Studio locally.
3. Go to Django admin panel and `ocw-www` starter config.
4. Paste the copied config and save.
5. Go to `ocw-www` stories via Studio and click on Add Story.
6. Make sure Name isn't present in the fields.
