### PR TITLE
Set default licensing pop-up warning for ERs to False

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -325,7 +325,7 @@ collections:
       - label: Include non-OCW licensing warning
         name: has_external_license_warning
         widget: boolean
-        default: true
+        default: false
         required: true
         help: >
           If true, user sees warning that external content is not

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -513,7 +513,7 @@ collections:
       - label: Include non-OCW licensing warning
         name: has_external_license_warning
         widget: boolean
-        default: true
+        default: false
         required: true
         help: >
           If true, user sees warning that external content is not


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6319

### Description (What does it do?)
This PR sets default licensing pop-up warning for ERs to False.

### How can this be tested?
Create a new ER in Studio locally with the updated config from this branch and make sure the `Include non-OCW licensing warning` is set to False by default.

