### PR TITLE
Remove headless: true

### DIFF
--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -562,7 +562,6 @@ collections:
         widget: string
         required: false
 
-
   - category: Settings
     label: Menu
     name: menu

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -234,11 +234,6 @@ collections:
         name: body
         widget: markdown
 
-      - label: Headless
-        name: headless
-        widget: hidden
-        default: true
-
   - category: Content
     folder: content/stories
     label: Stories
@@ -560,10 +555,12 @@ collections:
         widget: string
         required: false
 
-      - label: Headless
-        name: headless
+      - label: Build
+        name: _build
         widget: hidden
-        default: true
+        default:
+          render: "never"
+          list: "always"
 
   - category: Settings
     label: Menu

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -234,6 +234,13 @@ collections:
         name: body
         widget: markdown
 
+      - label: Build
+        name: _build
+        widget: hidden
+        default:
+          render: "never"
+          list: "always"
+
   - category: Content
     folder: content/stories
     label: Stories
@@ -555,12 +562,6 @@ collections:
         widget: string
         required: false
 
-      - label: Build
-        name: _build
-        widget: hidden
-        default:
-          render: "never"
-          list: "always"
 
   - category: Settings
     label: Menu


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/6895

### Description (What does it do?)
For instructors, removed `headless: true` because it no longer creates `index.json` files during build.
For notifications,  replaced `headless: true` with:
```
_build:
  list: always
  render: never
```
so that they can be iterated over.

### How can this be tested?
Checkout to this branch and copy the config to ocw-www starter locally in ocw-studio from django admin. Go to ocw-www site and create a notification and an instructor. Inspect the content markdown frontmatter from your GitHub ocw-www site repository.
Notification will have:
```
_build:
  list: always
  render: never
```
Instructor will not have `headless: true`.
