### PR TITLE
Upgrade CI GitHub Actions and Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ jobs:
   yaml-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 17.3.0
-      - uses: actions/setup-python@v2
+          node-version: 22
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13.x"
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Description
- Updated actions/checkout to v4
- Updated actions/setup-node to v4
- Updated Node.js version to 22 in CI workflow
- Updated actions/setup-python to v5

### How can this be tested?
Just look at this PR's CI checks details

