### PR TITLE
Add source in video_metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -256,6 +256,9 @@ collections:
           - label: Youtube Tags (comma separated; max 100 characters)
             name: video_tags
             widget: text
+          - label: Source
+            name: source
+            widget: hidden
       - label: Video Files
         name: video_files
         widget: object

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -443,6 +443,9 @@ collections:
           - label: Youtube Tags (comma separated; max 100 characters)
             name: video_tags
             widget: text
+          - label: Source
+            name: source
+            widget: hidden
       - label: Video Files
         name: video_files
         widget: object


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/6409

### Description (What does it do?)
Adds `source` in `video_metadata` to be used for syncing missing 3play captions for newly created video resources in Studio UI by using `source: youtube`

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
