### PR TITLE
Add new Learning Resource Types

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -185,7 +185,7 @@ collections:
           - "Online Textbook"
           - "Other Audio"
           - "Other Video"
-          - Podcast
+          - Podcasts
           - "Presentation Assignments"
           - "Presentation Assignments with Examples"
           - "Problem Sets"
@@ -465,7 +465,7 @@ collections:
               - "Online Textbook"
               - "Other Audio"
               - "Other Video"
-              - Podcast
+              - Podcasts
               - "Presentation Assignments"
               - "Presentation Assignments with Examples"
               - "Problem Sets"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -372,7 +372,7 @@ collections:
           - "Online Textbook"
           - "Other Audio"
           - "Other Video"
-          - Podcast
+          - Podcasts
           - "Presentation Assignments"
           - "Presentation Assignments with Examples"
           - "Problem Sets"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7140

### Description (What does it do?)
Adds new learning resources types:

- Source files
- Student work (course level only)
- Podcast

### How can this be tested?
Copy the config from this branch and paste onto your `WebsiteStarters` for `ocw-www` and `ocw-course`.. See that the changes are working locally.