### PR TITLE
updated tags for learning resource types

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -169,12 +169,11 @@ collections:
           - "Design Assignments"
           - "Design Assignments with Examples"
           - "Editable Files"
-          - "Exam Materials"
           - Exams
           - "Exams with Solutions"
           - "Image Gallery"
           - "Instructor Insights"
-          - Labs
+          - "Laboratory Assignments"
           - "Lecture Audio"
           - "Lecture Notes"
           - "Lecture Videos"
@@ -182,8 +181,8 @@ collections:
           - "Media Assignments with Examples"
           - "Multiple Assignment Types"
           - "Multiple Assignment Types with Solutions"
-          - Music
-          - "Online Textbook"
+          - "Music Audio"
+          - "Open Textbooks"
           - "Other Audio"
           - "Other Video"
           - Podcasts
@@ -191,15 +190,16 @@ collections:
           - "Presentation Assignments with Examples"
           - "Problem Sets"
           - "Problem Sets with Solutions"
+          - "Problem-solving Notes"
+          - "Problem-solving Videos"
           - "Programming Assignments"
           - "Programming Assignments with Examples"
           - Projects
           - "Projects with Examples"
           - Readings
-          - "Recitation Notes"
-          - "Recitation Videos"
           - "Simulation Videos"
           - Simulations
+          - "Supplemental Exam Materials"
           - Tools
           - "Tutorial Videos"
           - "Video Materials"
@@ -460,12 +460,11 @@ collections:
               - "Design Assignments"
               - "Design Assignments with Examples"
               - "Editable Files"
-              - "Exam Materials"
               - Exams
               - "Exams with Solutions"
               - "Image Gallery"
               - "Instructor Insights"
-              - Labs
+              - "Laboratory Assignments"
               - "Lecture Audio"
               - "Lecture Notes"
               - "Lecture Videos"
@@ -473,8 +472,8 @@ collections:
               - "Media Assignments with Examples"
               - "Multiple Assignment Types"
               - "Multiple Assignment Types with Solutions"
-              - Music
-              - "Online Textbook"
+              - "Music Audio"
+              - "Open Textbooks"
               - "Other Audio"
               - "Other Video"
               - Podcasts
@@ -482,16 +481,17 @@ collections:
               - "Presentation Assignments with Examples"
               - "Problem Sets"
               - "Problem Sets with Solutions"
+              - "Problem-solving Notes"
+              - "Problem-solving Videos"
               - "Programming Assignments"
               - "Programming Assignments with Examples"
               - Projects
               - "Projects with Examples"
               - Readings
-              - "Recitation Notes"
-              - "Recitation Videos"
               - "Simulation Videos"
               - Simulations
               - "Student Work"
+              - "Supplemental Exam Materials"
               - Tools
               - "Tutorial Videos"
               - "Video Materials"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -356,12 +356,11 @@ collections:
           - "Design Assignments"
           - "Design Assignments with Examples"
           - "Editable Files"
-          - "Exam Materials"
           - Exams
           - "Exams with Solutions"
           - "Image Gallery"
           - "Instructor Insights"
-          - Labs
+          - "Laboratory Assignments"
           - "Lecture Audio"
           - "Lecture Notes"
           - "Lecture Videos"
@@ -369,8 +368,8 @@ collections:
           - "Media Assignments with Examples"
           - "Multiple Assignment Types"
           - "Multiple Assignment Types with Solutions"
-          - Music
-          - "Online Textbook"
+          - "Music Audio"
+          - "Open Textbooks"
           - "Other Audio"
           - "Other Video"
           - Podcasts
@@ -378,15 +377,16 @@ collections:
           - "Presentation Assignments with Examples"
           - "Problem Sets"
           - "Problem Sets with Solutions"
+          - "Problem-solving Notes"
+          - "Problem-solving Videos"
           - "Programming Assignments"
           - "Programming Assignments with Examples"
           - Projects
           - "Projects with Examples"
           - Readings
-          - "Recitation Notes"
-          - "Recitation Videos"
           - "Simulation Videos"
           - Simulations
+          - "Supplemental Exam Materials"
           - Tools
           - "Tutorial Videos"
           - "Video Materials"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7649

### Description (What does it do?)
Update both the course level and resource level tags as follows:

Exam Materials -> Supplemental Exam Materials
Labs -> Laboratory Assignments
Music -> Music Audio
Online Textbook -> Open Textbooks
Recitation Videos -> Problem-solving Videos
Recitation Notes -> Problem-solving Notes

### How can this be tested?
This can be tested in OCW Studio. Spin up containers and paste the updated config in the starters in the Django admin. Check that the tags have been updated in the metadata form.