### PR TITLE
Remove Tools course learning resource type

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -516,7 +516,6 @@ collections:
               - Simulations
               - "Student Work"
               - "Supplemental Exam Materials"
-              - Tools
               - "Tutorial Videos"
               - "Video Materials"
               - Videos


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/9209.

### Description (What does it do?)
This PR removes `Tools` from OCW Studio at the course level only; it remains an option for resource learning resource types.

### How can this be tested?
Start OCW Studio locally by running `docker compose up`. Copy the contents of the starter in this PR into the `ocw-course` starter in Django admin, and verify that `Tools` is no longer an option for course-level learning resource types (in the Settings->Metadata for the course).