### PR TITLE
chore: removed image gallery lrt from resource level

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -176,7 +176,6 @@ collections:
           - "Editable Files"
           - Exams
           - "Exams with Solutions"
-          - "Image Gallery"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -363,7 +363,6 @@ collections:
           - "Editable Files"
           - Exams
           - "Exams with Solutions"
-          - "Image Gallery"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9210

### Description (What does it do?)
This PR removes the `Image Gallery` LRT at the resource level only.

### How can this be tested?
This can be tested in OCW Studio. Spin up containers and paste the updated config in the starters in the Django admin. Check that the tags have been updated in the metadata form.