### PR TITLE
chore: removed simulation lrt from course and resource level

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -203,7 +203,6 @@ collections:
           - "Projects with Examples"
           - Readings
           - "Simulation Videos"
-          - Simulations
           - "Supplemental Exam Materials"
           - Tools
           - "Tutorial Videos"
@@ -513,7 +512,6 @@ collections:
               - "Projects with Examples"
               - Readings
               - "Simulation Videos"
-              - Simulations
               - "Student Work"
               - "Supplemental Exam Materials"
               - "Tutorial Videos"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -390,7 +390,6 @@ collections:
           - "Projects with Examples"
           - Readings
           - "Simulation Videos"
-          - Simulations
           - "Supplemental Exam Materials"
           - Tools
           - "Tutorial Videos"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9208

### Description (What does it do?)
This PR removes the `Simulations` LRT at the course and resource levels.

### How can this be tested?
This can be tested in OCW Studio. Spin up containers and paste the updated config in the starters in the Django admin. Check that the tags have been updated in the metadata form.