### PR TITLE
Add course-v3 config

### DIFF
--- a/ocw-course-v3/config.yaml
+++ b/ocw-course-v3/config.yaml
@@ -1,0 +1,62 @@
+---
+baseUrl: "/"
+enableRobotsTXT: true
+languageCode: en-us
+relativeURLs: false
+title: MIT OpenCourseWare
+theme: ["course-v3", "base-theme"]
+ignoreErrors: ["error-remote-getjson"]
+outputFormats:
+  coursedata:
+    mediaType: "application/json"
+    baseName: "data"
+    isPlainText: true
+  contentmap:
+    mediaType: "application/json"
+    baseName: "content_map"
+    isPlainText: true
+outputs:
+  home:
+    - coursedata
+    - contentmap
+    - HTML
+  page:
+    - coursedata
+    - HTML
+  section:
+    - coursedata
+    - HTML
+security:
+  funcs:
+    getenv:
+      - ^HUGO_
+      - WEBPACK_HOST
+      - WEBPACK_PORT
+      - API_BEARER_TOKEN
+      - GTM_ACCOUNT_ID
+      - RESOURCE_BASE_URL
+      - STATIC_API_BASE_URL
+      - OCW_STUDIO_BASE_URL
+      - OCW_IMPORT_STARTER_SLUG
+      - OCW_COURSE_STARTER_SLUG
+      - COURSE_BASE_URL
+      - SITEMAP_DOMAIN
+      - SENTRY_DSN
+      - NOINDEX
+  http:
+    methods:
+      - (?i)GET|HEAD
+markup:
+  highlight:
+    style: colorful
+  goldmark:
+    renderer:
+      unsafe: true
+mediaTypes:
+  application/zip:
+    suffixes:
+      - zip
+taxonomies:
+  learning_resource_type: learning_resource_types
+permalinks:
+  learning_resource_types: "/resources/:slug/"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/9358.

### Description (What does it do?)
The PR adds a new `course-v3` config. This is necessary to be able to simultaneously generate both `course-v2` and `course-v3` builds as part of the development process for the new theme.

### How can this be tested?
This can be tested by following the same instructions as for testing https://github.com/mitodl/ocw-hugo-themes/pull/1674, but instead of modifying the line in the `course-v2` config, set the `COURSE_HUGO_CONFIG_PATH` variable to point to this new file in the `.env` for `ocw-hugo-projects`. Then, run `yarn start course` and note that the logo has changed to the MIT Learn logo.