### PR TITLE
Update configs to change Exams with Solutions LRT to Exam Solutions

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -175,7 +175,7 @@ collections:
           - "Design Assignments with Examples"
           - "Editable Files"
           - Exams
-          - "Exams with Solutions"
+          - "Exam Solutions"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"
@@ -483,7 +483,7 @@ collections:
               - "Design Assignments with Examples"
               - "Editable Files"
               - Exams
-              - "Exams with Solutions"
+              - "Exam Solutions"
               - "Image Gallery"
               - "Instructor Insights"
               - "Laboratory Assignments"

--- a/ocw-www/ocw-studio.yaml
+++ b/ocw-www/ocw-studio.yaml
@@ -362,7 +362,7 @@ collections:
           - "Design Assignments with Examples"
           - "Editable Files"
           - Exams
-          - "Exams with Solutions"
+          - "Exam Solutions"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/9764.

### Description (What does it do?)
This PR changes the learning resource type from `Exams with Solutions` to `Exam Solutions`.

### How can this be tested?
This should be tested by importing the config into OCW Studio and checking that the LRT options have been updated.