### PR TITLE
Use math-enabled minimal editor for resource description field

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -130,7 +130,7 @@ collections:
       - label: Description
         name: body
         widget: markdown
-        minimal: true
+        minimal: "with-math"
         link:
           - resource
           - page


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10051.

### Description (What does it do?)
This PR sets the `Description` fields in the `Edit Resource` modal to use the new MathJax-enabled minimal editor config.

### How can this be tested?
This is tested as part of testing https://github.com/mitodl/ocw-studio/pull/2869. However, this PR should only be merged after that PR has been merged and deployed.