### PR TITLE
Expand level metadata options and add level field for resources

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -210,6 +210,18 @@ collections:
           - "Workshop Videos"
           - "Written Assignments"
           - "Written Assignments with Examples"
+      - label: "Level"
+        name: "level"
+        widget: "select"
+        multiple: true
+        options:
+          - "Undergraduate"
+          - "Graduate"
+          - "Non-Credit"
+          - "Early Childhood"
+          - "Primary School"
+          - "Middle School"
+          - "High School"
       - label: License
         name: license
         options:
@@ -456,6 +468,9 @@ collections:
               - "Undergraduate"
               - "Graduate"
               - "Non-Credit"
+              - "Early Childhood"
+              - "Primary School"
+              - "Middle School"
               - "High School"
             widget: "select"
           - label: "Term"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10153.

### Description (What does it do?)
This PR makes two changes:
1. The levels metadata now includes `Early Childhood`, `Primary School`, and `Middle School` in addition to the currently-existing levels.
2. Resources, not just courses, now have a level metadata field, with the same options as for courses.

### How can this be tested?
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that both courses and resources can have any of the levels options indicated in this PR, including multiple levels.