### PR TITLE
Standardize LRT options across course metadata and resources

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -165,7 +165,7 @@ collections:
         name: "learning_resource_types"
         widget: select
         multiple: true
-        options:
+        options: &learning_resource_types
           - "Activity Assignments"
           - "Activity Assignments with Examples"
           - "Competition Videos"
@@ -174,8 +174,9 @@ collections:
           - "Design Assignments"
           - "Design Assignments with Examples"
           - "Editable Files"
-          - Exams
+          - "Exams"
           - "Exam Solutions"
+          - "Image Gallery"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"
@@ -189,7 +190,7 @@ collections:
           - "Open Textbooks"
           - "Other Audio"
           - "Other Video"
-          - Podcasts
+          - "Podcasts"
           - "Presentation Assignments"
           - "Presentation Assignments with Examples"
           - "Problem Sets"
@@ -198,15 +199,16 @@ collections:
           - "Problem-solving Videos"
           - "Programming Assignments"
           - "Programming Assignments with Examples"
-          - Projects
+          - "Projects"
           - "Projects with Examples"
-          - Readings
+          - "Readings"
           - "Simulation Videos"
+          - "Student Work"
           - "Supplemental Exam Materials"
-          - Tools
+          - "Tools"
           - "Tutorial Videos"
           - "Video Materials"
-          - Videos
+          - "Videos"
           - "Workshop Videos"
           - "Written Assignments"
           - "Written Assignments with Examples"
@@ -488,52 +490,7 @@ collections:
             name: "learning_resource_types"
             widget: select
             multiple: true
-            options:
-              - "Activity Assignments"
-              - "Activity Assignments with Examples"
-              - "Competition Videos"
-              - "Demonstration Audio"
-              - "Demonstration Videos"
-              - "Design Assignments"
-              - "Design Assignments with Examples"
-              - "Editable Files"
-              - Exams
-              - "Exam Solutions"
-              - "Image Gallery"
-              - "Instructor Insights"
-              - "Laboratory Assignments"
-              - "Lecture Audio"
-              - "Lecture Notes"
-              - "Lecture Videos"
-              - "Media Assignments"
-              - "Media Assignments with Examples"
-              - "Multiple Assignment Types"
-              - "Multiple Assignment Types with Solutions"
-              - "Music Audio"
-              - "Open Textbooks"
-              - "Other Audio"
-              - "Other Video"
-              - Podcasts
-              - "Presentation Assignments"
-              - "Presentation Assignments with Examples"
-              - "Problem Sets"
-              - "Problem Set Solutions"
-              - "Problem-solving Notes"
-              - "Problem-solving Videos"
-              - "Programming Assignments"
-              - "Programming Assignments with Examples"
-              - Projects
-              - "Projects with Examples"
-              - Readings
-              - "Simulation Videos"
-              - "Student Work"
-              - "Supplemental Exam Materials"
-              - "Tutorial Videos"
-              - "Video Materials"
-              - Videos
-              - "Workshop Videos"
-              - "Written Assignments"
-              - "Written Assignments with Examples"
+            options: *learning_resource_types
           - label: Instructors
             name: instructors
             widget: relation


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Part of ongoing work updating metadata fields, including Learning Resource Type (LRT) options.

### Description (What does it do?)
This PR standardizes the LRT options across resources and course metadata. Currently, resources don't have `Image Gallery` or `Student Work` as options but they do have `Tools` as an option. In contrast, course metadata has `Image Gallery` and `Student Work` as options but not `Tools`. This PR makes the update to use an anchor and aliases for LRT options to make further inconsistencies less likely.

### How can this be tested?
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that both resources and course metadata have the same LRT options available.
