### PR TITLE
Add Page metadata fields

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -46,7 +46,7 @@ collections:
         name: "learning_resource_types"
         widget: select
         multiple: true
-        options:
+        options: &learning_resource_types
           - "Activity Assignments"
           - "Activity Assignments with Examples"
           - "Competition Videos"
@@ -55,8 +55,9 @@ collections:
           - "Design Assignments"
           - "Design Assignments with Examples"
           - "Editable Files"
-          - Exams
+          - "Exams"
           - "Exam Solutions"
+          - "Image Gallery"
           - "Instructor Insights"
           - "Laboratory Assignments"
           - "Lecture Audio"
@@ -70,7 +71,7 @@ collections:
           - "Open Textbooks"
           - "Other Audio"
           - "Other Video"
-          - Podcasts
+          - "Podcasts"
           - "Presentation Assignments"
           - "Presentation Assignments with Examples"
           - "Problem Sets"
@@ -79,15 +80,16 @@ collections:
           - "Problem-solving Videos"
           - "Programming Assignments"
           - "Programming Assignments with Examples"
-          - Projects
+          - "Projects"
           - "Projects with Examples"
-          - Readings
+          - "Readings"
           - "Simulation Videos"
+          - "Student Work"
           - "Supplemental Exam Materials"
-          - Tools
+          - "Tools"
           - "Tutorial Videos"
           - "Video Materials"
-          - Videos
+          - "Videos"
           - "Workshop Videos"
           - "Written Assignments"
           - "Written Assignments with Examples"
@@ -104,7 +106,7 @@ collections:
         name: level
         widget: select
         multiple: true
-        options:
+        options: &level_options
           - "Undergraduate"
           - "Graduate"
           - "Non-Credit"
@@ -236,65 +238,12 @@ collections:
         name: "learning_resource_types"
         widget: select
         multiple: true
-        options: &learning_resource_types
-          - "Activity Assignments"
-          - "Activity Assignments with Examples"
-          - "Competition Videos"
-          - "Demonstration Audio"
-          - "Demonstration Videos"
-          - "Design Assignments"
-          - "Design Assignments with Examples"
-          - "Editable Files"
-          - "Exams"
-          - "Exam Solutions"
-          - "Image Gallery"
-          - "Instructor Insights"
-          - "Laboratory Assignments"
-          - "Lecture Audio"
-          - "Lecture Notes"
-          - "Lecture Videos"
-          - "Media Assignments"
-          - "Media Assignments with Examples"
-          - "Multiple Assignment Types"
-          - "Multiple Assignment Types with Solutions"
-          - "Music Audio"
-          - "Open Textbooks"
-          - "Other Audio"
-          - "Other Video"
-          - "Podcasts"
-          - "Presentation Assignments"
-          - "Presentation Assignments with Examples"
-          - "Problem Sets"
-          - "Problem Set Solutions"
-          - "Problem-solving Notes"
-          - "Problem-solving Videos"
-          - "Programming Assignments"
-          - "Programming Assignments with Examples"
-          - "Projects"
-          - "Projects with Examples"
-          - "Readings"
-          - "Simulation Videos"
-          - "Student Work"
-          - "Supplemental Exam Materials"
-          - "Tools"
-          - "Tutorial Videos"
-          - "Video Materials"
-          - "Videos"
-          - "Workshop Videos"
-          - "Written Assignments"
-          - "Written Assignments with Examples"
+        options: *learning_resource_types
       - label: "Level"
         name: "level"
         widget: "select"
         multiple: true
-        options:
-          - "Undergraduate"
-          - "Graduate"
-          - "Non-Credit"
-          - "Early Childhood"
-          - "Primary School"
-          - "Middle School"
-          - "High School"
+        options: *level_options
       - label: License
         name: license
         options:
@@ -537,14 +486,7 @@ collections:
           - label: "Level"
             name: "level"
             multiple: true
-            options:
-              - "Undergraduate"
-              - "Graduate"
-              - "Non-Credit"
-              - "Early Childhood"
-              - "Primary School"
-              - "Middle School"
-              - "High School"
+            options: *level_options
             widget: "select"
           - label: "Term"
             name: "term"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10156.

### Description (What does it do?)
This PR adds `Learning Resource Types`, `Level`, and `Audience` fields to Pages.

### How can this be tested?
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that Pages now have these fields available in the `Edit Page` drawer.
