### PR TITLE
Add Audience field to resources and site metadata

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -98,7 +98,7 @@ collections:
         name: audience
         widget: select
         multiple: true
-        options:
+        options: &audience_options
           - Educators
           - Learners
 
@@ -239,6 +239,11 @@ collections:
         widget: select
         multiple: true
         options: *learning_resource_types
+      - label: Audience
+        name: audience
+        widget: select
+        multiple: true
+        options: *audience_options
       - label: "Level"
         name: "level"
         widget: "select"
@@ -504,6 +509,11 @@ collections:
             widget: select
             multiple: true
             options: *learning_resource_types
+          - label: Audience
+            name: audience
+            widget: select
+            multiple: true
+            options: *audience_options
           - label: Instructors
             name: instructors
             widget: relation


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10154.

### Description (What does it do?)
This PR adds the `Audience` field to Resources and site Metadata, with the same options as for Pages (`Educators` and `Learners`).

### How can this be tested
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that Resources and the course Metadata now have `Audience` as an available field.