### PR TITLE
Add LRT metadata fields to resource lists and video galleries

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -46,7 +46,7 @@ collections:
         name: "learning_resource_types"
         widget: select
         multiple: true
-        options:
+        options: &page_lrt_options
           - "Activity Assignments"
           - "Activity Assignments with Examples"
           - "Competition Videos"
@@ -154,6 +154,12 @@ collections:
         name: description
         widget: markdown
 
+      - label: "Learning Resource Types"
+        name: "learning_resource_types"
+        widget: select
+        multiple: true
+        options: *page_lrt_options
+
       - name: resources
         label: Resources
         widget: relation
@@ -189,6 +195,12 @@ collections:
           - page
         embed:
           - resource
+
+      - label: "Learning Resource Types"
+        name: "learning_resource_types"
+        widget: select
+        multiple: true
+        options: *page_lrt_options
 
       - label: Videos
         name: videos


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10836.

### Description (What does it do?)
This PR adds the same Learning Resource Type (LRT) options that are currently available for pages to resource lists and video galleries.

### How can this be tested?
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that both resource lists and video galleries now have LRT options in their metadata for any course.
