### PR TITLE
chore: removed captions and transcript file fields

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -396,11 +396,8 @@ collections:
             multiple: false
             filter:
               field: "resourcetype"
-              filter_type: "equals"
-              value: "Other"
-          - label: Video Captions (WebVTT) URL
-            name: video_captions_file
-            widget: string
+              filter_type: "not_equals"
+              value: "Video"
           - label: Video Transcript Resource
             name: video_transcript_resource
             widget: relation
@@ -409,11 +406,8 @@ collections:
             multiple: false
             filter:
               field: "resourcetype"
-              filter_type: "equals"
-              value: "Document"
-          - label: Video Transcript (PDF) URL
-            name: video_transcript_file
-            widget: string
+              filter_type: "not_equals"
+              value: "Video"
           - label: Internet Archive URL
             name: archive_url
             widget: string

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -396,8 +396,8 @@ collections:
             multiple: false
             filter:
               field: "resourcetype"
-              filter_type: "not_equals"
-              value: "Video"
+              filter_type: "equals"
+              value: "Other"
           - label: Video Transcript Resource
             name: video_transcript_resource
             widget: relation
@@ -406,8 +406,8 @@ collections:
             multiple: false
             filter:
               field: "resourcetype"
-              filter_type: "not_equals"
-              value: "Video"
+              filter_type: "equals"
+              value: "Document"
           - label: Internet Archive URL
             name: archive_url
             widget: string


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10958

### Description (What does it do?)
Removes the legacy `video_captions_file` and `video_transcript_file` string fields from the `video_files` metadata block on video resources.