### PR TITLE
Remove Nuclear course topic

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -652,7 +652,6 @@ collections:
                 Fossil Fuels: []
                 Fuel Cells: []
                 Hydrogen and Alternatives: []
-                Nuclear: []
                 Nuclear Energy: []
                 Renewables: []
                 Technology: []


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/11207.

### Description (What does it do?)
This PR removes the `Nuclear` course topic. This is the last step in migrating courses from the `Nuclear` to the `Nuclear Energy` course topic.

### How can this be tested?
This should be tested in OCW Studio. First, start containers with `docker compose up`. Navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch. Verify that `Nuclear` does not appear as a course subtopic option (under the `Energy` topic).
