### PR TITLE
Remove "Open Textbooks" learning resource type from pages

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -68,7 +68,6 @@ collections:
           - "Multiple Assignment Types"
           - "Multiple Assignment Types with Solutions"
           - "Music Audio"
-          - "Open Textbooks"
           - "Other Audio"
           - "Other Video"
           - "Podcasts"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11882

### Description (What does it do?)
Removes the "Open Textbooks" option from the `learning_resource_types` field on the **page**, *video-gallery* and **resource-list** collection in `ocw-course-v2/ocw-studio.yaml`. 

### How can this be tested?
1. In ocw-studio, navigate to Django admin and replace the contents of the `ocw-course` starter with the contents of `ocw-course-v2/ocw-studio.yaml` from this branch.
2. Open the editor for a course **Page** and confirm "Open Textbooks" no longer appears in the "Learning Resource Types" dropdown, while it still appears for the other collections (e.g. resources).
