### PR TITLE
feat: add language and locale fields to the resource content type

### DIFF
--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -322,13 +322,6 @@ collections:
         widget: "select"
         multiple: true
         options: *level_options
-      - label: License
-        name: license
-        options: *license_options
-        widget: select
-        default: https://creativecommons.org/licenses/by-nc-sa/4.0/
-        required: true
-
       # Shown on every resource rather than only captions and transcripts:
       # `condition` supports a single `equals`, and captions are
       # resourcetype "Other" while transcripts are "Document", so the target
@@ -343,9 +336,6 @@ collections:
         required: false
         help: Language of this file. Detected from the filename when unset.
         options:
-          # Selecting this restores filename detection. Without it the widget
-          # is not clearable, so a mis-picked value could never be undone.
-          - {label: "Detect from filename", value: ""}
           - {label: English, value: en}
           - {label: Arabic, value: ar}
           - {label: Chinese, value: zh}
@@ -393,6 +383,13 @@ collections:
           - {label: "Taiwan (TW)", value: TW}
           - {label: "United Kingdom (GB)", value: GB}
           - {label: "United States (US)", value: US}
+
+      - label: License
+        name: license
+        options: *license_options
+        widget: select
+        default: https://creativecommons.org/licenses/by-nc-sa/4.0/
+        required: true
 
       # show the field below only if the type of resource is "image"
       - label: Image Metadata

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -341,8 +341,11 @@ collections:
         name: language
         widget: select
         required: false
-        help: The language of this file. Detected from the filename when left unset.
+        help: Language of this file. Detected from the filename when unset.
         options:
+          # Selecting this restores filename detection. Without it the widget
+          # is not clearable, so a mis-picked value could never be undone.
+          - {label: "Detect from filename", value: ""}
           - {label: English, value: en}
           - {label: Arabic, value: ar}
           - {label: Chinese, value: zh}
@@ -370,6 +373,9 @@ collections:
         required: false
         help: Optional regional variant, for example Portuguese (BR).
         options:
+          # Same reason as Language above: without an explicit empty option a
+          # mis-picked region could not be cleared back to none.
+          - {label: "No regional variant", value: ""}
           - {label: "Argentina (AR)", value: AR}
           - {label: "Australia (AU)", value: AU}
           - {label: "Austria (AT)", value: AT}

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -329,6 +329,65 @@ collections:
         default: https://creativecommons.org/licenses/by-nc-sa/4.0/
         required: true
 
+      # Shown on every resource rather than only captions and transcripts:
+      # `condition` supports a single `equals`, and captions are
+      # resourcetype "Other" while transcripts are "Document", so the target
+      # set is not expressible. Studio pre-fills these from the filename when
+      # unset, so an editor always sees the value that will publish.
+      # The language list must stay in step with human_language.html in
+      # ocw-hugo-themes, which maps exactly these 20 codes to display names
+      # and otherwise renders a bare uppercase code.
+      - label: Language
+        name: language
+        widget: select
+        required: false
+        help: The language of this file. Detected from the filename when left unset.
+        options:
+          - {label: English, value: en}
+          - {label: Arabic, value: ar}
+          - {label: Chinese, value: zh}
+          - {label: Dutch, value: nl}
+          - {label: French, value: fr}
+          - {label: German, value: de}
+          - {label: Hebrew, value: he}
+          - {label: Hindi, value: hi}
+          - {label: Italian, value: it}
+          - {label: Japanese, value: ja}
+          - {label: Korean, value: ko}
+          - {label: Polish, value: pl}
+          - {label: Portuguese, value: pt}
+          - {label: Russian, value: ru}
+          - {label: Spanish, value: es}
+          - {label: Swedish, value: sv}
+          - {label: Thai, value: th}
+          - {label: Turkish, value: tr}
+          - {label: Ukrainian, value: uk}
+          - {label: Vietnamese, value: vi}
+
+      - label: Locale
+        name: locale
+        widget: select
+        required: false
+        help: Optional regional variant, for example Portuguese (BR).
+        options:
+          - {label: "Argentina (AR)", value: AR}
+          - {label: "Australia (AU)", value: AU}
+          - {label: "Austria (AT)", value: AT}
+          - {label: "Brazil (BR)", value: BR}
+          - {label: "Canada (CA)", value: CA}
+          - {label: "China (CN)", value: CN}
+          - {label: "France (FR)", value: FR}
+          - {label: "Germany (DE)", value: DE}
+          - {label: "Hong Kong (HK)", value: HK}
+          - {label: "India (IN)", value: IN}
+          - {label: "Mexico (MX)", value: MX}
+          - {label: "Portugal (PT)", value: PT}
+          - {label: "Spain (ES)", value: ES}
+          - {label: "Switzerland (CH)", value: CH}
+          - {label: "Taiwan (TW)", value: TW}
+          - {label: "United Kingdom (GB)", value: GB}
+          - {label: "United States (US)", value: US}
+
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
         name: image_metadata

--- a/ocw-course-v2/ocw-studio.yaml
+++ b/ocw-course-v2/ocw-studio.yaml
@@ -363,9 +363,6 @@ collections:
         required: false
         help: Optional regional variant, for example Portuguese (BR).
         options:
-          # Same reason as Language above: without an explicit empty option a
-          # mis-picked region could not be cleared back to none.
-          - {label: "No regional variant", value: ""}
           - {label: "Argentina (AR)", value: AR}
           - {label: "Australia (AU)", value: AU}
           - {label: "Austria (AT)", value: AT}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12685

Paired with mitodl/ocw-studio#3137, which reads these fields. The two can merge in either order. Until ocw-studio ships, these fields save into metadata with no effect on output. Until this ships, ocw-studio finds no metadata value and behaves as it does today.

### Description (What does it do?)
Adds `Language` and `Locale` select fields to the `resource` collection in `ocw-course-v2/ocw-studio.yaml`, so a caption or transcript can be labeled from Studio instead of only by its filename.

Today the language is derived solely from the uploaded filename, which has to follow the `_captions-<lang>[-<locale>]` convention. A file that does not follow it cannot be labeled, and correcting a language means renaming the file.

Notes on the two choices that are not obvious from the diff:

- **Both fields appear on every resource, not only captions and transcripts.** `condition` supports a single `equals`, and captions are `resourcetype: Other` while transcripts are `Document`, so the target set is not expressible. Labeling other resource types is also a goal of the parent ticket.
- **Locale is optional and has no default.** A language without a region is the normal case, not a gap: `fr` is French, `fr-CA` is Canadian French, and both are valid `srclang` values. Defaulting would assert a region the file never claimed. The filename parser already returns no locale when the name carries no region, and `resource_file_paths` omits the key entirely in that case.

The 20 language options are exactly the codes `human_language.html` maps to display names in ocw-hugo-themes. Anything outside that set renders as a bare uppercase code such as "PT", so the two lists have to change together.

### How can this be tested?

This will be tested with https://github.com/mitodl/ocw-studio/pull/3137